### PR TITLE
Move CI to GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Typescript CI
+
+on: [push]
+
+permissions:
+  statuses: write
+  checks: write
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.6.x
+          cache: "yarn"
+      - run: yarn install
+      - run: yarn build
+      - run: yarn test:ci
+      - name: Test Reporter
+        uses: dorny/test-reporter@v1.5.0
+        if: always() # run this step even if previous step failed
+        with:
+          name: Build & Test Report # Name of the check run which will be created
+          path: ./junit.xml # Path to test results
+          reporter: jest-junit # Format of test results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           name: Build & Test Report # Name of the check run which will be created
           path: ./junit.xml # Path to test results
-          reporter: jest-junit # Format of test results
+          reporter: java-junit # Format of test results

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && webpack",
     "test": "vitest",
-    "test:ci": "vitest --reporter=tap",
+    "test:ci": "vitest --reporter=junit",
     "coverage": "vitest run --coverage"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && webpack",
     "test": "vitest",
-    "test:ci": "vitest --reporter=junit",
+    "test:ci": "vitest --reporter=junit --outputFile=junit.xml",
     "coverage": "vitest run --coverage"
   },
   "files": [

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -13,7 +13,7 @@ describe("init", () => {
     spyLog.mockImplementationOnce(() => null);
     bucketInstance.init(KEY, { debug: true });
     expect(spyInit).toHaveBeenCalled();
-    expect(spyLog).not.toHaveBeenCalled();
+    expect(spyLog).toHaveBeenCalled();
   });
 
   test("will accept setup with custom host", async () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -13,7 +13,7 @@ describe("init", () => {
     spyLog.mockImplementationOnce(() => null);
     bucketInstance.init(KEY, { debug: true });
     expect(spyInit).toHaveBeenCalled();
-    expect(spyLog).toHaveBeenCalled();
+    expect(spyLog).not.toHaveBeenCalled();
   });
 
   test("will accept setup with custom host", async () => {


### PR DESCRIPTION
Example report: https://github.com/bucketco/bucket-tracking-sdk/runs/6921564709?check_suite_focus=true

I used the `java-junit` reporter here because `jest-unit` [did not work ](https://github.com/bucketco/bucket-tracking-sdk/runs/6921439826?check_suite_focus=true). 

Annotations are not quite right, but i didn't find a way to fix them.