### PR TITLE
Life-time management of feedback prompts in the SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-unused-imports": "^3.0.0",
     "globals": "^13.21.0",
+    "jsdom": "^22.1.0",
     "nock": "^13.3.3",
     "prettier": "^3.0.2",
     "ts-loader": "^9.4.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "types": "./dist/types/src/index.d.ts",
   "devDependencies": {
     "@eslint/js": "^8.47.0",
+    "@types/js-cookie": "^3.0.3",
     "@types/node": "^18.16.20",
     "@types/webpack": "^5.28.1",
     "@types/webpack-node-externals": "^3.0.0",
@@ -52,6 +53,7 @@
   "dependencies": {
     "ably": "^1.2.43",
     "cross-fetch": "^4.0.0",
-    "is-bundling-for-browser-or-node": "^1.1.1"
+    "is-bundling-for-browser-or-node": "^1.1.1",
+    "js-cookie": "^3.0.5"
   }
 }

--- a/src/ably.ts
+++ b/src/ably.ts
@@ -5,7 +5,7 @@ export async function openAblyConnection(
   userId: string,
   channel: string,
   callback: (req: object) => void,
-  debug?: boolean
+  debug?: boolean,
 ) {
   const client = new Ably.Realtime.Promise({
     authUrl: authUrl,

--- a/src/ably.ts
+++ b/src/ably.ts
@@ -5,7 +5,7 @@ export async function openAblyConnection(
   userId: string,
   channel: string,
   callback: (req: object) => void,
-  debug?: boolean,
+  debug?: boolean
 ) {
   const client = new Ably.Realtime.Promise({
     authUrl: authUrl,
@@ -14,7 +14,11 @@ export async function openAblyConnection(
       userId,
     },
   });
-  const c = client.channels.get(channel);
+  const c = client.channels.get(channel, {
+    params: {
+      rewind: "1",
+    },
+  });
   await c.subscribe((message) => {
     callback(message.data);
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -227,6 +227,7 @@ export default function main() {
     if (ablyClient) {
       err("Feedback prompting already initialized. Use reset() first.");
     }
+
     userId = resolveUser(userId);
 
     const res = await request(`${getUrl()}/feedback/prompting-init`, {
@@ -254,7 +255,6 @@ export default function main() {
         ),
       debug
     );
-
     log(`feedback prompting connection established`);
     return res;
   }
@@ -264,6 +264,7 @@ export default function main() {
     message: any,
     userCallback: FeedbackPromptHandler | undefined
   ) {
+    console.log("handleFeedbackPromptRequest", message);
     const parsed = parsePromptMessage(message);
     if (!parsed) {
       err(`invalid feedback prompt message received`, message);

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,7 +58,7 @@ export default function main() {
   function getSessionUser() {
     if (!sessionUserId) {
       err(
-        "User is not set, please call user() first or provide userId as argument"
+        "User is not set, please call user() first or provide userId as argument",
       );
     }
     return sessionUserId;
@@ -118,7 +118,7 @@ export default function main() {
   async function user(
     userId: User["userId"],
     attributes?: User["attributes"],
-    context?: Context
+    context?: Context,
   ) {
     checkKey();
     if (!userId) err("No userId provided");
@@ -145,7 +145,7 @@ export default function main() {
     companyId: Company["companyId"],
     attributes?: Company["attributes"] | null,
     userId?: Company["userId"],
-    context?: Context
+    context?: Context,
   ) {
     checkKey();
     if (!companyId) err("No companyId provided");
@@ -167,7 +167,7 @@ export default function main() {
     attributes?: TrackedEvent["attributes"] | null,
     userId?: Company["userId"],
     companyId?: Company["companyId"],
-    context?: Context
+    context?: Context,
   ) {
     checkKey();
     if (!eventName) err("No eventName provided");
@@ -224,7 +224,7 @@ export default function main() {
 
   async function initFeedbackPrompting(
     userId?: User["userId"],
-    handler?: FeedbackPromptHandler
+    handler?: FeedbackPromptHandler,
   ) {
     checkKey();
     if (isForNode) {
@@ -260,7 +260,7 @@ export default function main() {
       userId,
       body.channel,
       (message) => handleFeedbackPromptRequest(userId!, message, actualHandler),
-      debug
+      debug,
     );
     log(`feedback prompting connection established`);
     return res;
@@ -269,7 +269,7 @@ export default function main() {
   function handleFeedbackPromptRequest(
     userId: User["userId"],
     message: any,
-    userCallback: FeedbackPromptHandler
+    userCallback: FeedbackPromptHandler,
   ) {
     const parsed = parsePromptMessage(message);
     if (!parsed) {
@@ -279,12 +279,12 @@ export default function main() {
 
       if (
         !processPromptMessage(userId, parsed, (u, m, cb) =>
-          triggerFeedbackPrompt(u, m, cb, userCallback)
+          triggerFeedbackPrompt(u, m, cb, userCallback),
         )
       ) {
         log(
           `feedback prompt not shown, it was either expired or already processed`,
-          message
+          message,
         );
       }
     }
@@ -294,13 +294,13 @@ export default function main() {
     userId: User["userId"],
     message: FeedbackPrompt,
     actioned: FeedbackPromptActionedHandler,
-    handler: FeedbackPromptHandler
+    handler: FeedbackPromptHandler,
   ) {
     if (feedbackPromptingUserId !== userId) {
       log(
         `feedback prompt not shown, received for another user`,
         userId,
-        message
+        message,
       );
       return;
     }
@@ -328,7 +328,7 @@ export default function main() {
   async function feedbackPromptEvent(
     promptId: string,
     event: "received" | "shown" | "dismissed",
-    userId: User["userId"]
+    userId: User["userId"],
   ) {
     checkKey();
     if (!promptId) err("No promptId provided");

--- a/src/prompt-storage.ts
+++ b/src/prompt-storage.ts
@@ -1,0 +1,15 @@
+export const markPromptMessageCompleted = (
+  userId: string,
+  promptId: string,
+) => {
+  localStorage.setItem(`prompt-${userId}`, promptId);
+};
+
+export const checkPromptMessageCompleted = (
+  userId: string,
+  promptId: string,
+) => {
+  console.log(userId, promptId);
+  const id = localStorage.getItem(`prompt-${userId}`);
+  return id === promptId;
+};

--- a/src/prompt-storage.ts
+++ b/src/prompt-storage.ts
@@ -12,6 +12,6 @@ export const checkPromptMessageCompleted = (
   userId: string,
   promptId: string,
 ) => {
-  const id = Cookies.get(`prompt-${userId}`);
+  const id = Cookies.get(`bucket-prompt-${userId}`);
   return id === promptId;
 };

--- a/src/prompt-storage.ts
+++ b/src/prompt-storage.ts
@@ -5,7 +5,7 @@ export const markPromptMessageCompleted = (
   promptId: string,
   expiresAt: Date,
 ) => {
-  Cookies.set(`prompt-${userId}`, promptId, { expires: expiresAt });
+  Cookies.set(`bucket-prompt-${userId}`, promptId, { expires: expiresAt });
 };
 
 export const checkPromptMessageCompleted = (

--- a/src/prompt-storage.ts
+++ b/src/prompt-storage.ts
@@ -1,15 +1,17 @@
+import Cookies from "js-cookie";
+
 export const markPromptMessageCompleted = (
   userId: string,
   promptId: string,
+  expiresAt: Date,
 ) => {
-  localStorage.setItem(`prompt-${userId}`, promptId);
+  Cookies.set(`prompt-${userId}`, promptId, { expires: expiresAt });
 };
 
 export const checkPromptMessageCompleted = (
   userId: string,
   promptId: string,
 ) => {
-  console.log(userId, promptId);
-  const id = localStorage.getItem(`prompt-${userId}`);
+  const id = Cookies.get(`prompt-${userId}`);
   return id === promptId;
 };

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,13 +1,17 @@
 import { FeedbackPrompt } from "./types";
 
 export const parsePromptMessage = (
-  message: any,
+  message: any
 ): FeedbackPrompt | undefined => {
   if (
     typeof message?.question !== "string" ||
     !message.question.length ||
-    typeof message?.showAfter !== "number" ||
-    typeof message?.showBefore !== "number"
+    typeof message.showAfter !== "number" ||
+    typeof message.showBefore !== "number" ||
+    typeof message.promptId !== "string" ||
+    !message.promptId.length ||
+    typeof message.featureId !== "string" ||
+    !message.featureId.length
   ) {
     return undefined;
   } else {
@@ -15,6 +19,45 @@ export const parsePromptMessage = (
       question: message.question,
       showAfter: new Date(message.showAfter),
       showBefore: new Date(message.showBefore),
+      promptId: message.promptId,
+      featureId: message.featureId,
     };
+  }
+};
+
+const rememberMessage = (userId: string, promptId: string) => {
+  localStorage.setItem(`prompt-${userId}`, promptId);
+};
+
+export type FeedbackPromptActionedCallback = () => void;
+export type ShowPromptCallback = (
+  userId: string,
+  prompt: FeedbackPrompt,
+  actionedCallback: FeedbackPromptActionedCallback
+) => void;
+
+export const processPromptMessage = (
+  userId: string,
+  prompt: FeedbackPrompt,
+  showCallback: ShowPromptCallback
+) => {
+  const now = new Date();
+
+  const actionedCallback = () => {
+    rememberMessage(userId, prompt.promptId);
+  };
+
+  if (now > prompt.showBefore) {
+    rememberMessage(userId, prompt.promptId);
+    return false;
+  } else if (now < prompt.showAfter) {
+    setTimeout(() => {
+      showCallback(userId, prompt, actionedCallback);
+    }, prompt.showAfter.getTime() - now.getTime());
+
+    return true;
+  } else {
+    showCallback(userId, prompt, actionedCallback);
+    return true;
   }
 };

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,4 +1,4 @@
-import { FeedbackPrompt } from "./types";
+import { FeedbackPrompt, User } from "./types";
 
 export const parsePromptMessage = (
   message: any,
@@ -34,21 +34,21 @@ const seenMessage = (userId: string, promptId: string) => {
   return id === promptId;
 };
 
-export type FeedbackPromptActionedCallback = () => void;
-export type ShowPromptCallback = (
-  userId: string,
+export type FeedbackPromptCompletionHandler = () => void;
+export type FeedbackPromptDisplayHandler = (
+  userId: User["userId"],
   prompt: FeedbackPrompt,
-  actionedCallback: FeedbackPromptActionedCallback,
+  completionHandler: FeedbackPromptCompletionHandler,
 ) => void;
 
 export const processPromptMessage = (
-  userId: string,
+  userId: User["userId"],
   prompt: FeedbackPrompt,
-  showCallback: ShowPromptCallback,
+  displayHandler: FeedbackPromptDisplayHandler,
 ) => {
   const now = new Date();
 
-  const actionedCallback = () => {
+  const completionHandler = () => {
     rememberMessage(userId, prompt.promptId);
   };
 
@@ -59,12 +59,12 @@ export const processPromptMessage = (
     return false;
   } else if (now < prompt.showAfter) {
     setTimeout(() => {
-      showCallback(userId, prompt, actionedCallback);
+      displayHandler(userId, prompt, completionHandler);
     }, prompt.showAfter.getTime() - now.getTime());
 
     return true;
   } else {
-    showCallback(userId, prompt, actionedCallback);
+    displayHandler(userId, prompt, completionHandler);
     return true;
   }
 };

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,7 +1,7 @@
 import { FeedbackPrompt } from "./types";
 
 export const parsePromptMessage = (
-  message: any
+  message: any,
 ): FeedbackPrompt | undefined => {
   if (
     typeof message?.question !== "string" ||
@@ -38,13 +38,13 @@ export type FeedbackPromptActionedCallback = () => void;
 export type ShowPromptCallback = (
   userId: string,
   prompt: FeedbackPrompt,
-  actionedCallback: FeedbackPromptActionedCallback
+  actionedCallback: FeedbackPromptActionedCallback,
 ) => void;
 
 export const processPromptMessage = (
   userId: string,
   prompt: FeedbackPrompt,
-  showCallback: ShowPromptCallback
+  showCallback: ShowPromptCallback,
 ) => {
   const now = new Date();
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,3 +1,7 @@
+import {
+  checkPromptMessageCompleted,
+  markPromptMessageCompleted,
+} from "./prompt-storage";
 import { FeedbackPrompt, User } from "./types";
 
 export const parsePromptMessage = (
@@ -25,15 +29,6 @@ export const parsePromptMessage = (
   }
 };
 
-const rememberMessage = (userId: string, promptId: string) => {
-  localStorage.setItem(`prompt-${userId}`, promptId);
-};
-
-const seenMessage = (userId: string, promptId: string) => {
-  const id = localStorage.getItem(`prompt-${userId}`);
-  return id === promptId;
-};
-
 export type FeedbackPromptCompletionHandler = () => void;
 export type FeedbackPromptDisplayHandler = (
   userId: User["userId"],
@@ -49,13 +44,13 @@ export const processPromptMessage = (
   const now = new Date();
 
   const completionHandler = () => {
-    rememberMessage(userId, prompt.promptId);
+    markPromptMessageCompleted(userId, prompt.promptId);
   };
 
-  if (seenMessage(userId, prompt.promptId)) {
+  if (checkPromptMessageCompleted(userId, prompt.promptId)) {
     return false;
   } else if (now > prompt.showBefore) {
-    rememberMessage(userId, prompt.promptId);
+    markPromptMessageCompleted(userId, prompt.promptId);
     return false;
   } else if (now < prompt.showAfter) {
     setTimeout(() => {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -44,13 +44,12 @@ export const processPromptMessage = (
   const now = new Date();
 
   const completionHandler = () => {
-    markPromptMessageCompleted(userId, prompt.promptId);
+    markPromptMessageCompleted(userId, prompt.promptId, prompt.showBefore);
   };
 
   if (checkPromptMessageCompleted(userId, prompt.promptId)) {
     return false;
   } else if (now > prompt.showBefore) {
-    markPromptMessageCompleted(userId, prompt.promptId);
     return false;
   } else if (now < prompt.showAfter) {
     setTimeout(() => {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -29,6 +29,11 @@ const rememberMessage = (userId: string, promptId: string) => {
   localStorage.setItem(`prompt-${userId}`, promptId);
 };
 
+const seenMessage = (userId: string, promptId: string) => {
+  const id = localStorage.getItem(`prompt-${userId}`);
+  return id === promptId;
+};
+
 export type FeedbackPromptActionedCallback = () => void;
 export type ShowPromptCallback = (
   userId: string,
@@ -47,7 +52,9 @@ export const processPromptMessage = (
     rememberMessage(userId, prompt.promptId);
   };
 
-  if (now > prompt.showBefore) {
+  if (seenMessage(userId, prompt.promptId)) {
+    return false;
+  } else if (now > prompt.showBefore) {
     rememberMessage(userId, prompt.promptId);
     return false;
   } else if (now < prompt.showAfter) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,8 @@ export type FeedbackPrompt = {
   question: string;
   showAfter: Date;
   showBefore: Date;
+  promptId: string;
+  featureId: string;
 };
 
 export type FeedbackPromptCallback = (req: FeedbackPrompt) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export type Key = string;
 export type Options = {
   persistUser?: boolean;
   automaticFeedbackPrompting?: boolean;
-  feedbackPromptCallback?: FeedbackPromptCallback;
+  feedbackPromptHandler?: FeedbackPromptHandler;
   host?: string;
   debug?: boolean;
 };
@@ -18,7 +18,7 @@ export type User = {
 };
 
 export type Company = {
-  userId: string;
+  userId: User["userId"];
   companyId: string;
   attributes?: {
     name?: string;
@@ -29,8 +29,8 @@ export type Company = {
 
 export type TrackedEvent = {
   event: string;
-  userId: string;
-  companyId?: string;
+  userId: User["userId"];
+  companyId?: Company["companyId"];
   attributes?: {
     [key: string]: any;
   };
@@ -39,10 +39,11 @@ export type TrackedEvent = {
 
 export type Feedback = {
   featureId: string;
-  userId: string;
-  companyId?: string;
+  userId: User["userId"];
+  companyId?: Company["companyId"];
   score?: number;
   comment?: string;
+  promptId?: FeedbackPrompt["promptId"];
 };
 
 export type FeedbackPrompt = {
@@ -50,10 +51,20 @@ export type FeedbackPrompt = {
   showAfter: Date;
   showBefore: Date;
   promptId: string;
-  featureId: string;
+  featureId: Feedback["featureId"];
 };
 
-export type FeedbackPromptCallback = (req: FeedbackPrompt) => void;
+export type FeedbackPromptReply = {
+  companyId?: Company["companyId"];
+  score?: Feedback["score"];
+  comment?: Feedback["comment"];
+};
+
+export type FeedbackPromptReplyHandler = (reply?: FeedbackPromptReply) => void;
+export type FeedbackPromptHandler = (
+  req: FeedbackPrompt,
+  replyCallback: FeedbackPromptReplyHandler
+) => void;
 
 export type Context = {
   active?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,12 +61,12 @@ export type FeedbackPromptReply = {
 };
 
 export type FeedbackPromptReplyHandler = (
-  reply: FeedbackPromptReply | null
+  reply: FeedbackPromptReply | null,
 ) => void;
 
 export type FeedbackPromptHandler = (
   req: FeedbackPrompt,
-  replyCallback: FeedbackPromptReplyHandler
+  replyCallback: FeedbackPromptReplyHandler,
 ) => void;
 
 export type Context = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,10 @@ export type FeedbackPromptReply = {
   comment?: Feedback["comment"];
 };
 
-export type FeedbackPromptReplyHandler = (reply?: FeedbackPromptReply) => void;
+export type FeedbackPromptReplyHandler = (
+  reply: FeedbackPromptReply | null
+) => void;
+
 export type FeedbackPromptHandler = (
   req: FeedbackPrompt,
   replyCallback: FeedbackPromptReplyHandler

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export type TrackedEvent = {
 
 export type Feedback = {
   featureId: string;
-  userId: User["userId"];
+  userId?: User["userId"];
   companyId?: Company["companyId"];
   score?: number;
   comment?: string;
@@ -65,8 +65,8 @@ export type FeedbackPromptReplyHandler = (
 ) => void;
 
 export type FeedbackPromptHandler = (
-  req: FeedbackPrompt,
-  replyCallback: FeedbackPromptReplyHandler,
+  prompt: FeedbackPrompt,
+  replyHandler: FeedbackPromptReplyHandler,
 ) => void;
 
 export type Context = {

--- a/test/ably.test.ts
+++ b/test/ably.test.ts
@@ -1,0 +1,52 @@
+import { Realtime } from "ably/promises";
+import { describe, expect, test, vi } from "vitest";
+
+import { closeAblyConnection, openAblyConnection } from "../src/ably";
+
+vi.mock("ably/promises");
+
+describe("ably", () => {
+  test("calls the ably constructor with expected arguments", async () => {
+    const channelFn = vi.fn();
+    const client = {
+      channels: {
+        get: vi.fn().mockReturnValue({ subscribe: channelFn }),
+      },
+    };
+    const spy = vi.spyOn(Realtime, "Promise").mockReturnValue(client as any);
+
+    const callback = vi.fn();
+    const expClient = await openAblyConnection(
+      "https://example.com",
+      "user",
+      "channel",
+      callback,
+    );
+
+    expect(expClient).toBe(client);
+    expect(spy).toHaveBeenCalledWith({
+      authUrl: "https://example.com",
+      log: { level: 1 },
+      authParams: {
+        userId: "user",
+      },
+    });
+
+    expect(client.channels.get).toHaveBeenCalledWith("channel", {
+      params: {
+        rewind: "1",
+      },
+    });
+
+    expect(channelFn).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  test("calls the ably close function", async () => {
+    const client = {
+      close: vi.fn(),
+    };
+
+    closeAblyConnection(client as any);
+    expect(client.close).toHaveBeenCalled();
+  });
+});

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,7 +1,7 @@
+import * as bundling from "is-bundling-for-browser-or-node";
 import nock from "nock";
 import { describe, expect, test, vi } from "vitest";
 
-import * as bundling from "is-bundling-for-browser-or-node";
 import bucket from "../src/main";
 
 const KEY = "123";
@@ -34,14 +34,14 @@ describe("init", () => {
 
   test("will reject setup without key", async () => {
     expect(() => bucket().init("")).toThrowError(
-      "Tracking key was not provided"
+      "Tracking key was not provided",
     );
   });
 
   test("will reject user call without key", async () => {
     const bucketInstance = bucket();
     await expect(() => bucketInstance.user("foo")).rejects.toThrowError(
-      "Tracking key is not set, please call init() first"
+      "Tracking key is not set, please call init() first",
     );
   });
 
@@ -53,9 +53,9 @@ describe("init", () => {
       bucketInstance.init(KEY, {
         automaticFeedbackPrompting: true,
         persistUser: false,
-      })
+      }),
     ).toThrowError(
-      "Feedback prompting is not supported when persistUser is disabled"
+      "Feedback prompting is not supported when persistUser is disabled",
     );
   });
 
@@ -67,9 +67,9 @@ describe("init", () => {
       bucketInstance.init(KEY, {
         automaticFeedbackPrompting: true,
         persistUser: false,
-      })
+      }),
     ).toThrowError(
-      "Feedback prompting is not supported in Node.js environment"
+      "Feedback prompting is not supported in Node.js environment",
     );
   });
 });

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,10 +1,13 @@
 import nock from "nock";
 import { describe, expect, test, vi } from "vitest";
 
+import * as bundling from "is-bundling-for-browser-or-node";
 import bucket from "../src/main";
 
 const KEY = "123";
 const CUSTOM_HOST = "https://example.com";
+
+vi.mock("is-bundling-for-browser-or-node");
 
 describe("init", () => {
   test("will accept setup with key and debug flag", () => {
@@ -31,26 +34,42 @@ describe("init", () => {
 
   test("will reject setup without key", async () => {
     expect(() => bucket().init("")).toThrowError(
-      "Tracking key was not provided",
+      "Tracking key was not provided"
     );
   });
 
   test("will reject user call without key", async () => {
     const bucketInstance = bucket();
     await expect(() => bucketInstance.user("foo")).rejects.toThrowError(
-      "Tracking key is not set, please call init() first",
+      "Tracking key is not set, please call init() first"
     );
   });
 
   test("will reject automatic feedback prompting if not persisting user", async () => {
+    vi.spyOn(bundling, "isForNode", "get").mockReturnValue(false);
+
     const bucketInstance = bucket();
     expect(() =>
       bucketInstance.init(KEY, {
         automaticFeedbackPrompting: true,
         persistUser: false,
-      }),
+      })
     ).toThrowError(
-      "Feedback prompting is not supported when persistUser is disabled",
+      "Feedback prompting is not supported when persistUser is disabled"
+    );
+  });
+
+  test("will reject automatic feedback prompting if in node environment", async () => {
+    vi.spyOn(bundling, "isForNode", "get").mockReturnValue(true);
+
+    const bucketInstance = bucket();
+    expect(() =>
+      bucketInstance.init(KEY, {
+        automaticFeedbackPrompting: true,
+        persistUser: false,
+      })
+    ).toThrowError(
+      "Feedback prompting is not supported in Node.js environment"
     );
   });
 });

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -14,7 +14,7 @@ describe("prompt-storage", () => {
 
     markPromptMessageCompleted("user", "prompt", new Date("2021-01-01"));
 
-    expect(spy).toHaveBeenCalledWith("prompt-user", "prompt", {
+    expect(spy).toHaveBeenCalledWith("bucket-prompt-user", "prompt", {
       expires: new Date("2021-01-01"),
     });
   });
@@ -24,7 +24,7 @@ describe("prompt-storage", () => {
 
     expect(checkPromptMessageCompleted("user", "prompt")).toBe(true);
 
-    expect(spy).toHaveBeenCalledWith("prompt-user");
+    expect(spy).toHaveBeenCalledWith("bucket-prompt-user");
   });
 
   test("checkPromptMessageCompleted with negative result", async () => {
@@ -32,6 +32,6 @@ describe("prompt-storage", () => {
 
     expect(checkPromptMessageCompleted("user", "prompt")).toBe(false);
 
-    expect(spy).toHaveBeenCalledWith("prompt-user");
+    expect(spy).toHaveBeenCalledWith("bucket-prompt-user");
   });
 });

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -1,0 +1,37 @@
+import Cookies from "js-cookie";
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  checkPromptMessageCompleted,
+  markPromptMessageCompleted,
+} from "../src/prompt-storage";
+
+vi.mock("js-cookie");
+
+describe("prompt-storage", () => {
+  test("markPromptMessageCompleted", async () => {
+    const spy = vi.spyOn(Cookies, "set");
+
+    markPromptMessageCompleted("user", "prompt", new Date("2021-01-01"));
+
+    expect(spy).toHaveBeenCalledWith("prompt-user", "prompt", {
+      expires: new Date("2021-01-01"),
+    });
+  });
+
+  test("checkPromptMessageCompleted with positive result", async () => {
+    const spy = vi.spyOn(Cookies, "get").mockReturnValue("prompt" as any);
+
+    expect(checkPromptMessageCompleted("user", "prompt")).toBe(true);
+
+    expect(spy).toHaveBeenCalledWith("prompt-user");
+  });
+
+  test("checkPromptMessageCompleted with negative result", async () => {
+    const spy = vi.spyOn(Cookies, "get").mockReturnValue("other" as any);
+
+    expect(checkPromptMessageCompleted("user", "prompt")).toBe(false);
+
+    expect(spy).toHaveBeenCalledWith("prompt-user");
+  });
+});

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -36,14 +36,6 @@ describe("parsePromptMessage", () => {
       parsePromptMessage({
         question: "hello?",
         showAfter: Date.now(),
-        promptId: "123",
-        featureId: "123",
-      }),
-    ).toBeUndefined();
-    expect(
-      parsePromptMessage({
-        question: "hello?",
-        showAfter: Date.now(),
         showBefore: Date.now(),
       }),
     ).toBeUndefined();

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -1,26 +1,67 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { parsePromptMessage } from "../src/prompts";
+import { parsePromptMessage, processPromptMessage } from "../src/prompts";
 
 describe("parsePromptMessage", () => {
   test("will not parse invalid messages", () => {
     expect(parsePromptMessage(undefined)).toBeUndefined();
     expect(parsePromptMessage("invalid")).toBeUndefined();
     expect(
-      parsePromptMessage({ showAfter: Date.now(), showBefore: Date.now() }),
+      parsePromptMessage({ showAfter: Date.now(), showBefore: Date.now() })
     ).toBeUndefined();
     expect(
       parsePromptMessage({
         question: "",
         showAfter: Date.now(),
         showBefore: Date.now(),
-      }),
+      })
     ).toBeUndefined();
     expect(
-      parsePromptMessage({ question: "hello?", showBefore: Date.now() }),
+      parsePromptMessage({
+        question: "hello?",
+        showBefore: Date.now(),
+        promptId: "123",
+        featureId: "123",
+      })
     ).toBeUndefined();
     expect(
-      parsePromptMessage({ question: "hello?", showAfter: Date.now() }),
+      parsePromptMessage({
+        question: "hello?",
+        showAfter: Date.now(),
+        promptId: "123",
+        featureId: "123",
+      })
+    ).toBeUndefined();
+    expect(
+      parsePromptMessage({
+        question: "hello?",
+        showAfter: Date.now(),
+        promptId: "123",
+        featureId: "123",
+      })
+    ).toBeUndefined();
+    expect(
+      parsePromptMessage({
+        question: "hello?",
+        showAfter: Date.now(),
+        showBefore: Date.now(),
+      })
+    ).toBeUndefined();
+    expect(
+      parsePromptMessage({
+        question: "hello?",
+        showAfter: Date.now(),
+        showBefore: Date.now(),
+        promptId: "123",
+      })
+    ).toBeUndefined();
+    expect(
+      parsePromptMessage({
+        question: "hello?",
+        showAfter: Date.now(),
+        showBefore: Date.now(),
+        featureId: "123",
+      })
     ).toBeUndefined();
   });
 
@@ -33,11 +74,98 @@ describe("parsePromptMessage", () => {
         question: "hello?",
         showAfter: start,
         showBefore: end,
-      }),
+        promptId: "123",
+        featureId: "456",
+      })
     ).toEqual({
       question: "hello?",
       showAfter: new Date(start),
       showBefore: new Date(end),
+      promptId: "123",
+      featureId: "456",
     });
+  });
+});
+
+describe("processPromptMessage", () => {
+  const now = Date.now();
+  const promptTemplate = {
+    question: "hello?",
+    promptId: "123",
+    featureId: "456",
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.useRealTimers();
+  });
+
+  test("will not process expired prompts", () => {
+    const prompt = {
+      ...promptTemplate,
+      showAfter: new Date(now - 1000),
+      showBefore: new Date(now - 500),
+    };
+
+    const showCallback = vi.fn();
+
+    expect(processPromptMessage("user", prompt, showCallback)).toBe(false);
+
+    expect(showCallback).not.toHaveBeenCalled();
+    expect(localStorage.getItem("prompt-user")).toBe("123");
+  });
+
+  test("will process prompts that are ready to be shown", () => {
+    const prompt = {
+      ...promptTemplate,
+      showAfter: new Date(now - 500),
+      showBefore: new Date(now + 500),
+    };
+
+    const showCallback = vi
+      .fn()
+      .mockImplementation((_a, _b, actionedCallback) => {
+        actionedCallback();
+      });
+
+    expect(processPromptMessage("user", prompt, showCallback)).toBe(true);
+    expect(showCallback).toHaveBeenCalledWith(
+      "user",
+      prompt,
+      expect.any(Function)
+    );
+
+    expect(localStorage.getItem("prompt-user")).toBe("123");
+  });
+
+  test("will process and delay prompts that are not yet ready to be shown", () => {
+    const prompt = {
+      ...promptTemplate,
+      showAfter: new Date(now + 500),
+      showBefore: new Date(now + 1000),
+    };
+
+    const showCallback = vi
+      .fn()
+      .mockImplementation((_a, _b, actionedCallback) => {
+        actionedCallback();
+      });
+
+    expect(processPromptMessage("user", prompt, showCallback)).toBe(true);
+    expect(showCallback).not.toHaveBeenCalled();
+    expect(localStorage.getItem("prompt-user")).toBeNull();
+
+    vi.runAllTimers();
+    expect(showCallback).toHaveBeenCalledWith(
+      "user",
+      prompt,
+      expect.any(Function)
+    );
+
+    expect(localStorage.getItem("prompt-user")).toBe("123");
   });
 });

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -104,6 +104,22 @@ describe("processPromptMessage", () => {
     vi.useRealTimers();
   });
 
+  test("will not process seen prompts", () => {
+    localStorage.setItem("prompt-user", "123");
+
+    const prompt = {
+      ...promptTemplate,
+      showAfter: new Date(now - 1000),
+      showBefore: new Date(now + 1000),
+    };
+
+    const showCallback = vi.fn();
+
+    expect(processPromptMessage("user", prompt, showCallback)).toBe(false);
+
+    expect(showCallback).not.toHaveBeenCalled();
+  });
+
   test("will not process expired prompts", () => {
     const prompt = {
       ...promptTemplate,

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -138,8 +138,7 @@ describe("processPromptMessage", () => {
 
     expect(showCallback).not.toHaveBeenCalled();
 
-    expect(markPromptMessageCompleted).toHaveBeenCalledOnce();
-    expect(markPromptMessageCompleted).toBeCalledWith("user", "123");
+    expect(markPromptMessageCompleted).not.toHaveBeenCalled();
   });
 
   test("will process prompts that are ready to be shown", () => {
@@ -163,7 +162,11 @@ describe("processPromptMessage", () => {
     );
 
     expect(markPromptMessageCompleted).toHaveBeenCalledOnce();
-    expect(markPromptMessageCompleted).toBeCalledWith("user", "123");
+    expect(markPromptMessageCompleted).toBeCalledWith(
+      "user",
+      "123",
+      prompt.showBefore,
+    );
   });
 
   test("will process and delay prompts that are not yet ready to be shown", () => {
@@ -191,6 +194,10 @@ describe("processPromptMessage", () => {
     );
 
     expect(markPromptMessageCompleted).toHaveBeenCalledOnce();
-    expect(markPromptMessageCompleted).toBeCalledWith("user", "123");
+    expect(markPromptMessageCompleted).toBeCalledWith(
+      "user",
+      "123",
+      prompt.showBefore,
+    );
   });
 });

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -7,14 +7,14 @@ describe("parsePromptMessage", () => {
     expect(parsePromptMessage(undefined)).toBeUndefined();
     expect(parsePromptMessage("invalid")).toBeUndefined();
     expect(
-      parsePromptMessage({ showAfter: Date.now(), showBefore: Date.now() })
+      parsePromptMessage({ showAfter: Date.now(), showBefore: Date.now() }),
     ).toBeUndefined();
     expect(
       parsePromptMessage({
         question: "",
         showAfter: Date.now(),
         showBefore: Date.now(),
-      })
+      }),
     ).toBeUndefined();
     expect(
       parsePromptMessage({
@@ -22,7 +22,7 @@ describe("parsePromptMessage", () => {
         showBefore: Date.now(),
         promptId: "123",
         featureId: "123",
-      })
+      }),
     ).toBeUndefined();
     expect(
       parsePromptMessage({
@@ -30,7 +30,7 @@ describe("parsePromptMessage", () => {
         showAfter: Date.now(),
         promptId: "123",
         featureId: "123",
-      })
+      }),
     ).toBeUndefined();
     expect(
       parsePromptMessage({
@@ -38,14 +38,14 @@ describe("parsePromptMessage", () => {
         showAfter: Date.now(),
         promptId: "123",
         featureId: "123",
-      })
+      }),
     ).toBeUndefined();
     expect(
       parsePromptMessage({
         question: "hello?",
         showAfter: Date.now(),
         showBefore: Date.now(),
-      })
+      }),
     ).toBeUndefined();
     expect(
       parsePromptMessage({
@@ -53,7 +53,7 @@ describe("parsePromptMessage", () => {
         showAfter: Date.now(),
         showBefore: Date.now(),
         promptId: "123",
-      })
+      }),
     ).toBeUndefined();
     expect(
       parsePromptMessage({
@@ -61,7 +61,7 @@ describe("parsePromptMessage", () => {
         showAfter: Date.now(),
         showBefore: Date.now(),
         featureId: "123",
-      })
+      }),
     ).toBeUndefined();
   });
 
@@ -76,7 +76,7 @@ describe("parsePromptMessage", () => {
         showBefore: end,
         promptId: "123",
         featureId: "456",
-      })
+      }),
     ).toEqual({
       question: "hello?",
       showAfter: new Date(start),
@@ -152,7 +152,7 @@ describe("processPromptMessage", () => {
     expect(showCallback).toHaveBeenCalledWith(
       "user",
       prompt,
-      expect.any(Function)
+      expect.any(Function),
     );
 
     expect(localStorage.getItem("prompt-user")).toBe("123");
@@ -179,7 +179,7 @@ describe("processPromptMessage", () => {
     expect(showCallback).toHaveBeenCalledWith(
       "user",
       prompt,
-      expect.any(Function)
+      expect.any(Function),
     );
 
     expect(localStorage.getItem("prompt-user")).toBe("123");

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -168,12 +168,12 @@ describe("usage", () => {
     await bucketInstance.user("fooUser");
 
     await expect(() =>
-      bucketInstance.company("fooCompany"),
+      bucketInstance.company("fooCompany")
     ).rejects.toThrowError("No userId provided and persistUser is disabled");
     await bucketInstance.company("fooCompany", null, "fooUser");
 
     await expect(() => bucketInstance.track("fooEvent")).rejects.toThrowError(
-      "No userId provided and persistUser is disabled",
+      "No userId provided and persistUser is disabled"
     );
     await bucketInstance.track("fooEvent", null, "fooUser");
   });
@@ -210,7 +210,7 @@ describe("usage", () => {
 
     bucketInstance.reset();
     await expect(() => bucketInstance.track("foo")).rejects.toThrowError(
-      "User is not set, please call user() first",
+      "User is not set, please call user() first"
     );
   });
 });
@@ -237,9 +237,9 @@ describe("feedback prompting", () => {
     bucketInstance.init(KEY);
 
     await expect(
-      bucketInstance.initFeedbackPrompting("foo"),
+      bucketInstance.initFeedbackPrompting("foo")
     ).rejects.toThrowError(
-      "Feedback prompting is not supported in Node.js environment",
+      "Feedback prompting is not supported in Node.js environment"
     );
   });
 
@@ -261,7 +261,7 @@ describe("feedback prompting", () => {
       "foo",
       "test-channel",
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
 
     // call twice, expect only one reset to go through
@@ -339,9 +339,9 @@ describe("feedback prompting", () => {
 
     await bucketInstance.initFeedbackPrompting("foo");
     await expect(() =>
-      bucketInstance.initFeedbackPrompting("foo"),
+      bucketInstance.initFeedbackPrompting("foo")
     ).rejects.toThrowError(
-      "Feedback prompting already initialized. Use reset() first.",
+      "Feedback prompting already initialized. Use reset() first."
     );
   });
 });
@@ -374,14 +374,14 @@ describe("feedback state management", () => {
         (_a, _b_, _c, callback, _d) => {
           callback(goodMessage);
           return Promise.resolve("fake_client" as any);
-        },
+        }
       );
     } else if (tc.meta.name.includes("blocks")) {
       vi.mocked(openAblyConnection).mockImplementation(
         (_a, _b_, _c, callback, _d) => {
           callback(badMessage);
           return Promise.resolve("fake_client" as any);
-        },
+        }
       );
     }
 
@@ -491,13 +491,27 @@ describe("feedback state management", () => {
         promptId: "123",
         featureId: "456",
       },
-      expect.anything(),
+      expect.anything()
     );
 
     expectAsyncNockDone(n1);
     expectAsyncNockDone(n2);
 
     expect(localStorage.getItem("prompt-foo")).toBeNull();
+  });
+
+  test("propagates prompt to the init-supplied callback", async () => {
+    setupFeedbackPromptEventNock("received");
+    setupFeedbackPromptEventNock("shown");
+
+    const callback = vi.fn();
+
+    const bi = bucket();
+    bi.init(KEY, { persistUser: false, feedbackPromptHandler: callback });
+
+    await bi.initFeedbackPrompting("foo", callback);
+
+    expect(callback).toBeCalledTimes(1);
   });
 
   test("propagates timed prompt to the callback", async () => {
@@ -580,7 +594,7 @@ describe("feedback state management", () => {
     const callback = vi.fn();
 
     await expect(
-      bucketInstance.initFeedbackPrompting("foo", callback),
+      bucketInstance.initFeedbackPrompting("foo", callback)
     ).rejects.toThrowError();
 
     expect(callback).not.toBeCalled;

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -1,3 +1,4 @@
+import * as bundling from "is-bundling-for-browser-or-node";
 import nock from "nock";
 import {
   afterEach,
@@ -14,7 +15,6 @@ import { closeAblyConnection, openAblyConnection } from "../src/ably";
 import { TRACKING_HOST } from "../src/config";
 import bucket from "../src/main";
 import { FeedbackPrompt, FeedbackPromptReplyHandler } from "../src/types";
-import * as bundling from "is-bundling-for-browser-or-node";
 
 const KEY = "123";
 
@@ -168,12 +168,12 @@ describe("usage", () => {
     await bucketInstance.user("fooUser");
 
     await expect(() =>
-      bucketInstance.company("fooCompany")
+      bucketInstance.company("fooCompany"),
     ).rejects.toThrowError("No userId provided and persistUser is disabled");
     await bucketInstance.company("fooCompany", null, "fooUser");
 
     await expect(() => bucketInstance.track("fooEvent")).rejects.toThrowError(
-      "No userId provided and persistUser is disabled"
+      "No userId provided and persistUser is disabled",
     );
     await bucketInstance.track("fooEvent", null, "fooUser");
   });
@@ -210,7 +210,7 @@ describe("usage", () => {
 
     bucketInstance.reset();
     await expect(() => bucketInstance.track("foo")).rejects.toThrowError(
-      "User is not set, please call user() first"
+      "User is not set, please call user() first",
     );
   });
 });
@@ -237,9 +237,9 @@ describe("feedback prompting", () => {
     bucketInstance.init(KEY);
 
     await expect(
-      bucketInstance.initFeedbackPrompting("foo")
+      bucketInstance.initFeedbackPrompting("foo"),
     ).rejects.toThrowError(
-      "Feedback prompting is not supported in Node.js environment"
+      "Feedback prompting is not supported in Node.js environment",
     );
   });
 
@@ -261,7 +261,7 @@ describe("feedback prompting", () => {
       "foo",
       "test-channel",
       expect.anything(),
-      expect.anything()
+      expect.anything(),
     );
 
     // call twice, expect only one reset to go through
@@ -339,9 +339,9 @@ describe("feedback prompting", () => {
 
     await bucketInstance.initFeedbackPrompting("foo");
     await expect(() =>
-      bucketInstance.initFeedbackPrompting("foo")
+      bucketInstance.initFeedbackPrompting("foo"),
     ).rejects.toThrowError(
-      "Feedback prompting already initialized. Use reset() first."
+      "Feedback prompting already initialized. Use reset() first.",
     );
   });
 });
@@ -374,14 +374,14 @@ describe("feedback state management", () => {
         (_a, _b_, _c, callback, _d) => {
           callback(goodMessage);
           return Promise.resolve("fake_client" as any);
-        }
+        },
       );
     } else if (tc.meta.name.includes("blocks")) {
       vi.mocked(openAblyConnection).mockImplementation(
         (_a, _b_, _c, callback, _d) => {
           callback(badMessage);
           return Promise.resolve("fake_client" as any);
-        }
+        },
       );
     }
 
@@ -491,7 +491,7 @@ describe("feedback state management", () => {
         promptId: "123",
         featureId: "456",
       },
-      expect.anything()
+      expect.anything(),
     );
 
     expectAsyncNockDone(n1);
@@ -580,7 +580,7 @@ describe("feedback state management", () => {
     const callback = vi.fn();
 
     await expect(
-      bucketInstance.initFeedbackPrompting("foo", callback)
+      bucketInstance.initFeedbackPrompting("foo", callback),
     ).rejects.toThrowError();
 
     expect(callback).not.toBeCalled;

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -168,12 +168,12 @@ describe("usage", () => {
     await bucketInstance.user("fooUser");
 
     await expect(() =>
-      bucketInstance.company("fooCompany")
+      bucketInstance.company("fooCompany"),
     ).rejects.toThrowError("No userId provided and persistUser is disabled");
     await bucketInstance.company("fooCompany", null, "fooUser");
 
     await expect(() => bucketInstance.track("fooEvent")).rejects.toThrowError(
-      "No userId provided and persistUser is disabled"
+      "No userId provided and persistUser is disabled",
     );
     await bucketInstance.track("fooEvent", null, "fooUser");
   });
@@ -210,7 +210,7 @@ describe("usage", () => {
 
     bucketInstance.reset();
     await expect(() => bucketInstance.track("foo")).rejects.toThrowError(
-      "User is not set, please call user() first"
+      "User is not set, please call user() first",
     );
   });
 });
@@ -237,9 +237,9 @@ describe("feedback prompting", () => {
     bucketInstance.init(KEY);
 
     await expect(
-      bucketInstance.initFeedbackPrompting("foo")
+      bucketInstance.initFeedbackPrompting("foo"),
     ).rejects.toThrowError(
-      "Feedback prompting is not supported in Node.js environment"
+      "Feedback prompting is not supported in Node.js environment",
     );
   });
 
@@ -261,7 +261,7 @@ describe("feedback prompting", () => {
       "foo",
       "test-channel",
       expect.anything(),
-      expect.anything()
+      expect.anything(),
     );
 
     // call twice, expect only one reset to go through
@@ -339,9 +339,9 @@ describe("feedback prompting", () => {
 
     await bucketInstance.initFeedbackPrompting("foo");
     await expect(() =>
-      bucketInstance.initFeedbackPrompting("foo")
+      bucketInstance.initFeedbackPrompting("foo"),
     ).rejects.toThrowError(
-      "Feedback prompting already initialized. Use reset() first."
+      "Feedback prompting already initialized. Use reset() first.",
     );
   });
 });
@@ -374,14 +374,14 @@ describe("feedback state management", () => {
         (_a, _b_, _c, callback, _d) => {
           callback(goodMessage);
           return Promise.resolve("fake_client" as any);
-        }
+        },
       );
     } else if (tc.meta.name.includes("blocks")) {
       vi.mocked(openAblyConnection).mockImplementation(
         (_a, _b_, _c, callback, _d) => {
           callback(badMessage);
           return Promise.resolve("fake_client" as any);
-        }
+        },
       );
     }
 
@@ -491,7 +491,7 @@ describe("feedback state management", () => {
         promptId: "123",
         featureId: "456",
       },
-      expect.anything()
+      expect.anything(),
     );
 
     expectAsyncNockDone(n1);
@@ -594,7 +594,7 @@ describe("feedback state management", () => {
     const callback = vi.fn();
 
     await expect(
-      bucketInstance.initFeedbackPrompting("foo", callback)
+      bucketInstance.initFeedbackPrompting("foo", callback),
     ).rejects.toThrowError();
 
     expect(callback).not.toBeCalled;

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -163,12 +163,12 @@ describe("usage", () => {
     await bucketInstance.user("fooUser");
 
     await expect(() =>
-      bucketInstance.company("fooCompany"),
+      bucketInstance.company("fooCompany")
     ).rejects.toThrowError("No userId provided and persistUser is disabled");
     await bucketInstance.company("fooCompany", null, "fooUser");
 
     await expect(() => bucketInstance.track("fooEvent")).rejects.toThrowError(
-      "No userId provided and persistUser is disabled",
+      "No userId provided and persistUser is disabled"
     );
     await bucketInstance.track("fooEvent", null, "fooUser");
   });
@@ -205,7 +205,7 @@ describe("usage", () => {
 
     bucketInstance.reset();
     await expect(() => bucketInstance.track("foo")).rejects.toThrowError(
-      "User is not set, please call user() first",
+      "User is not set, please call user() first"
     );
   });
 });
@@ -214,6 +214,8 @@ const message = {
   question: "How are you",
   showAfter: new Date().valueOf(),
   showBefore: new Date().valueOf(),
+  promptId: "123",
+  featureId: "456",
 };
 
 describe("feedback prompting", () => {
@@ -227,11 +229,11 @@ describe("feedback prompting", () => {
               _a: string,
               _b: string,
               _c: string,
-              callback: (data: any) => void,
+              callback: (data: any) => void
             ) => {
               callback(message);
               return Promise.resolve("fake_client");
-            },
+            }
           ),
         closeAblyConnection: vi.fn(),
       };
@@ -265,7 +267,7 @@ describe("feedback prompting", () => {
       "foo",
       "test-channel",
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
 
     // call twice, expect only one reset to go through
@@ -351,6 +353,8 @@ describe("feedback prompting", () => {
       question: "How are you",
       showAfter: new Date(message.showAfter),
       showBefore: new Date(message.showBefore),
+      promptId: "123",
+      featureId: "456",
     });
   });
 
@@ -364,9 +368,9 @@ describe("feedback prompting", () => {
 
     await bucketInstance.initFeedbackPrompting("foo");
     await expect(() =>
-      bucketInstance.initFeedbackPrompting("foo"),
+      bucketInstance.initFeedbackPrompting("foo")
     ).rejects.toThrowError(
-      "Feedback prompting already initialized. Use reset() first.",
+      "Feedback prompting already initialized. Use reset() first."
     );
   });
 });

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -570,7 +570,11 @@ describe("feedback state management", () => {
     expectAsyncNockDone(n3);
 
     expect(markPromptMessageCompleted).toHaveBeenCalledOnce();
-    expect(markPromptMessageCompleted).toHaveBeenCalledWith("foo", "123");
+    expect(markPromptMessageCompleted).toHaveBeenCalledWith(
+      "foo",
+      "123",
+      new Date(goodMessage.showBefore),
+    );
   });
 
   test("propagates prompt to the callback and reacts to feedback", async () => {
@@ -604,7 +608,11 @@ describe("feedback state management", () => {
     expectAsyncNockDone(n3);
 
     expect(markPromptMessageCompleted).toHaveBeenCalledOnce();
-    expect(markPromptMessageCompleted).toHaveBeenCalledWith("foo", "123");
+    expect(markPromptMessageCompleted).toHaveBeenCalledWith(
+      "foo",
+      "123",
+      new Date(goodMessage.showBefore),
+    );
   });
 
   test("blocks invalid messages", async () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,6 +373,11 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@tootallnate/once@2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
+  integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
@@ -1002,6 +1007,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+abab@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
+  integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
+
 ably@^1.2.43:
   version "1.2.43"
   resolved "https://registry.yarnpkg.com/ably/-/ably-1.2.43.tgz#60b4048132ff2ccddb88fc5f79029c8c6704db12"
@@ -1040,6 +1050,13 @@ acorn@^8.4.1, acorn@^8.5.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 ajv-keywords@^3.5.2:
   version "3.5.2"
@@ -1166,6 +1183,11 @@ async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 available-typed-arrays@^1.0.5:
   version "1.0.5"
@@ -1397,6 +1419,13 @@ colors@~1.2.1:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.5.tgz#89c7ad9a374bc030df8013241f68136ed8835afc"
   integrity sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^10.0.0, commander@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
@@ -1454,6 +1483,22 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cssstyle@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-3.0.0.tgz#17ca9c87d26eac764bb8cfd00583cff21ce0277a"
+  integrity sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==
+  dependencies:
+    rrweb-cssom "^0.6.0"
+
+data-urls@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-4.0.0.tgz#333a454eca6f9a5b7b0f1013ff89074c3f522dd4"
+  integrity sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==
+  dependencies:
+    abab "^2.0.6"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^12.0.0"
+
 date-time@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/date-time/-/date-time-3.1.0.tgz#0d1e934d170579f481ed8df1e2b8ff70ee845e1e"
@@ -1465,6 +1510,13 @@ de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
+
+debug@4, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 debug@^3.2.7:
   version "3.2.7"
@@ -1480,12 +1532,10 @@ debug@^4.1.0:
   dependencies:
     ms "2.1.2"
 
-debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
+decimal.js@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
+  integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
 
 decompress-response@^6.0.0:
   version "6.0.0"
@@ -1519,6 +1569,11 @@ define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -1544,6 +1599,13 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+domexception@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-4.0.0.tgz#4ad1be56ccadc86fc76d033353999a8037d03673"
+  integrity sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==
+  dependencies:
+    webidl-conversions "^7.0.0"
 
 electron-to-chromium@^1.4.76:
   version "1.4.80"
@@ -1577,6 +1639,11 @@ enhanced-resolve@^5.12.0, enhanced-resolve@^5.15.0:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
+
+entities@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 envinfo@^7.7.3:
   version "7.8.1"
@@ -1988,6 +2055,15 @@ foreground-child@^2.0.0:
     cross-spawn "^7.0.0"
     signal-exit "^3.0.2"
 
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 fs-extra@~7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
@@ -2206,6 +2282,13 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+html-encoding-sniffer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
+  integrity sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==
+  dependencies:
+    whatwg-encoding "^2.0.0"
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -2216,6 +2299,15 @@ http-cache-semantics@^4.0.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
+http-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
+  dependencies:
+    "@tootallnate/once" "2"
+    agent-base "6"
+    debug "4"
+
 http2-wrapper@^1.0.0-beta.5.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.3.tgz#b8f55e0c1f25d4ebd08b3b0c2c079f9590800b3d"
@@ -2223,6 +2315,21 @@ http2-wrapper@^1.0.0-beta.5.2:
   dependencies:
     quick-lru "^5.1.1"
     resolve-alpn "^1.0.0"
+
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ignore@^5.2.0, ignore@^5.2.4:
   version "5.2.4"
@@ -2376,6 +2483,11 @@ is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
@@ -2490,6 +2602,35 @@ js-yaml@^4.1.0:
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
+
+jsdom@^22.1.0:
+  version "22.1.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-22.1.0.tgz#0fca6d1a37fbeb7f4aac93d1090d782c56b611c8"
+  integrity sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==
+  dependencies:
+    abab "^2.0.6"
+    cssstyle "^3.0.0"
+    data-urls "^4.0.0"
+    decimal.js "^10.4.3"
+    domexception "^4.0.0"
+    form-data "^4.0.0"
+    html-encoding-sniffer "^3.0.0"
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.1"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.4"
+    parse5 "^7.1.2"
+    rrweb-cssom "^0.6.0"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^4.1.2"
+    w3c-xmlserializer "^4.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^2.0.0"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^12.0.1"
+    ws "^8.13.0"
+    xml-name-validator "^4.0.0"
 
 json-buffer@3.0.1:
   version "3.0.1"
@@ -2691,6 +2832,18 @@ mime-db@1.51.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mime-types@^2.1.27:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
@@ -2793,6 +2946,11 @@ normalize-url@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
+
+nwsapi@^2.2.4:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.7.tgz#738e0707d3128cb750dddcfe90e4610482df0f30"
+  integrity sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==
 
 object-inspect@^1.12.3, object-inspect@^1.9.0:
   version "1.12.3"
@@ -2913,6 +3071,13 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse5@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz#0736bebbfd77793823240a23b7fc5e010b7f8e32"
+  integrity sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==
+  dependencies:
+    entities "^4.4.0"
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -3007,6 +3172,11 @@ propagate@^2.0.0:
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
   integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
+psl@^1.1.33:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
+  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
+
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -3019,6 +3189,16 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+punycode@^2.1.1, punycode@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
+  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -3062,6 +3242,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 resolve-alpn@^1.0.0:
   version "1.2.1"
@@ -3133,6 +3318,11 @@ rollup@^3.27.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
+rrweb-cssom@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz#ed298055b97cbddcdeb278f904857629dec5e0e1"
+  integrity sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -3168,6 +3358,18 @@ safe-regex-test@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
 
 schema-utils@^3.1.0, schema-utils@^3.1.1:
   version "3.1.1"
@@ -3390,6 +3592,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
@@ -3482,6 +3689,23 @@ to-utf8@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/to-utf8/-/to-utf8-0.0.1.tgz#d17aea72ff2fba39b9e43601be7b3ff72e089852"
   integrity sha512-zks18/TWT1iHO3v0vFp5qLKOG27m67ycq/Y7a7cTiRuUNlc4gf3HGnkRgMv0NyhnfTamtkYBJl+YeD1/j07gBQ==
+
+tough-cookie@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
+  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
+tr46@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-4.1.1.tgz#281a758dcc82aeb4fe38c7dfe4d11a395aac8469"
+  integrity sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==
+  dependencies:
+    punycode "^2.3.0"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -3618,12 +3842,25 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
@@ -3728,6 +3965,13 @@ vue-tsc@^1.8.8:
     "@vue/typescript" "1.8.8"
     semver "^7.3.8"
 
+w3c-xmlserializer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz#aebdc84920d806222936e3cdce408e32488a3073"
+  integrity sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==
+  dependencies:
+    xml-name-validator "^4.0.0"
+
 watchpack@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.3.1.tgz#4200d9447b401156eeca7767ee610f8809bc9d25"
@@ -3748,6 +3992,11 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
 webpack-cli@^5.1.4:
   version "5.1.4"
@@ -3851,6 +4100,26 @@ well-known-symbols@^2.0.0:
   resolved "https://registry.yarnpkg.com/well-known-symbols/-/well-known-symbols-2.0.0.tgz#e9c7c07dbd132b7b84212c8174391ec1f9871ba5"
   integrity sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==
 
+whatwg-encoding@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
+  integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
+  dependencies:
+    iconv-lite "0.6.3"
+
+whatwg-mimetype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
+  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
+
+whatwg-url@^12.0.0, whatwg-url@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-12.0.1.tgz#fd7bcc71192e7c3a2a97b9a8d6b094853ed8773c"
+  integrity sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==
+  dependencies:
+    tr46 "^4.1.1"
+    webidl-conversions "^7.0.0"
+
 whatwg-url@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
@@ -3921,6 +4190,21 @@ ws@^5.1:
   integrity sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==
   dependencies:
     async-limiter "~1.0.0"
+
+ws@^8.13.0:
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
+  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
+
+xml-name-validator@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
+  integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,6 +466,11 @@
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
   integrity sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==
 
+"@types/js-cookie@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.3.tgz#d6bfbbdd0c187354ca555213d1962f6d0691ff4e"
+  integrity sha512-Xe7IImK09HP1sv2M/aI+48a20VX+TdRJucfq4vfRVy6nWN8PYPOEnlMRSgxJAgYQIXJVL8dZ4/ilAM7dWNaOww==
+
 "@types/json-schema@*", "@types/json-schema@^7.0.8":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
@@ -2590,6 +2595,11 @@ jju@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
   integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
+
+js-cookie@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
+  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
 
 js-string-escape@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
BUC-1324 BUC-1321
- Now, properly managing the lifetime of the prompts within the SDK,
- Node.js environment is not allowed for feedback prompting (unless we later decide to enable that),
- Re-organized a number of type names to better suite us. Also, make sure to reuse the same type (user/company) across all calls,
- Testing all scenarios, including delayed prompts (in the future) and the situation where prompting is disabled with a pending future prompt (of another user's prompting is started),
- Added some additional tests to improve our coverage, seeing that this is a critically important library.