### PR TITLE
Use async calls instead of sync ones

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -121,6 +121,7 @@ module.exports = [
       // Typescript Specific
       "@typescript-eslint/no-unused-vars": "off", // handled by unused-imports
       "@typescript-eslint/explicit-module-boundary-types": ["off"],
+      "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/switch-exhaustiveness-check": ["warn"],
       "@typescript-eslint/no-non-null-assertion": ["off"],
       "@typescript-eslint/no-empty-function": ["warn"],

--- a/package.json
+++ b/package.json
@@ -53,12 +53,12 @@
     "vitest": "^0.30.1",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4",
-    "webpack-node-externals": "^3.0.0"
+    "webpack-node-externals": "^3.0.0",
+    "flush-promises": "^1.0.2"
   },
   "dependencies": {
     "ably": "^1.2.43",
     "cross-fetch": "^4.0.0",
-    "flush-promises": "^1.0.2",
     "is-bundling-for-browser-or-node": "^1.1.1",
     "js-cookie": "^3.0.5"
   }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "ably": "^1.2.43",
     "cross-fetch": "^4.0.0",
+    "flush-promises": "^1.0.2",
     "is-bundling-for-browser-or-node": "^1.1.1",
     "js-cookie": "^3.0.5"
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -253,9 +253,9 @@ export default function main() {
       err(`invalid feedback prompt message received`, message);
     } else {
       if (
-        !processPromptMessage(userId, parsed, (u, m, cb) => {
-          feedbackPromptEvent(parsed.promptId, "received", userId).then();
-          triggerFeedbackPrompt(u, m, cb);
+        !processPromptMessage(userId, parsed, async (u, m, cb) => {
+          await feedbackPromptEvent(parsed.promptId, "received", userId);
+          await triggerFeedbackPrompt(u, m, cb);
         })
       ) {
         log(
@@ -266,7 +266,7 @@ export default function main() {
     }
   }
 
-  function triggerFeedbackPrompt(
+  async function triggerFeedbackPrompt(
     userId: User["userId"],
     message: FeedbackPrompt,
     completionHandler: FeedbackPromptCompletionHandler,
@@ -280,20 +280,20 @@ export default function main() {
       return;
     }
 
-    feedbackPromptEvent(message.promptId, "shown", userId).then();
+    await feedbackPromptEvent(message.promptId, "shown", userId);
 
-    feedbackPromptHandler?.(message, (reply) => {
+    feedbackPromptHandler?.(message, async (reply) => {
       if (!reply) {
-        feedbackPromptEvent(message.promptId, "dismissed", userId).then();
+        await feedbackPromptEvent(message.promptId, "dismissed", userId);
       } else {
-        feedback({
+        await feedback({
           featureId: message.featureId,
           userId,
           companyId: reply.companyId,
           score: reply.score,
           comment: reply.comment,
           promptId: message.promptId,
-        }).then();
+        });
       }
 
       completionHandler();

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export type FeedbackPromptReply = {
 
 export type FeedbackPromptReplyHandler = (
   reply: FeedbackPromptReply | null,
-) => void;
+) => Promise<void>;
 
 export type FeedbackPromptHandler = (
   prompt: FeedbackPrompt,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,6 +2045,11 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
+flush-promises@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/flush-promises/-/flush-promises-1.0.2.tgz#4948fd58f15281fed79cbafc86293d5bb09b2ced"
+  integrity sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"


### PR DESCRIPTION
This PR makes the calls inside the feature prompting `async` instead of creating naked promises. This will help clients to actually catch errors on submit instead of always assuming that submit was successful. Also, some internal calls do now also use `await` in order to guarantee that the signals we expect actually arrive in out tracking endpoint.