### PR TITLE
Support translating strings within the widget

### DIFF
--- a/dev/app.tsx
+++ b/dev/app.tsx
@@ -1,7 +1,7 @@
 import { h } from "preact";
 import { useState } from "preact/hooks";
 
-import { FeedbackPlacement } from "../src/feedback/types";
+import { FeedbackPlacement, FeedbackTranslations } from "../src/feedback/types";
 import bucket from "../src/index";
 
 bucket.init("123", {
@@ -19,8 +19,24 @@ const ThemeButton = ({ theme }: { theme?: string }) => (
   </button>
 );
 
+const CUSTOM_TRANSLATIONS: FeedbackTranslations = {
+  DefaultQuestionLabel:
+    "Dans quelle mesure êtes-vous satisfait de cette fonctionnalité ?",
+  QuestionPlaceholder: "Comment pouvons-nous améliorer cette fonctionnalité ?",
+  CommentLabel: "Laissez un commentaire (facultative)",
+  ScoreVeryDissatisfiedLabel: "Très insatisfait",
+  ScoreDissatisfiedLabel: "Insatisfait",
+  ScoreNeutralLabel: "Neutre",
+  ScoreSatisfiedLabel: "Satisfait",
+  ScoreVerySatisfiedLabel: "Très satisfait",
+  SuccessMessage: "Merci d'avoir envoyé vos commentaires!",
+  SendButton: "Envoyer",
+};
+
 export function App() {
   const [placement, setPlacement] = useState<FeedbackPlacement>("bottom-right");
+  const [customTranslations, setCustomTranslations] = useState(false);
+
   return (
     <main style="display: flex; flex-direction: column; gap: 20px;">
       <h1>Bucket tracking playground</h1>
@@ -44,6 +60,14 @@ export function App() {
           <option value="top-right">Top right</option>
           <option value="top-left">Top left</option>
         </select>
+        <label>
+          <input
+            type="checkbox"
+            checked={customTranslations}
+            onInput={(e) => setCustomTranslations(e.currentTarget.checked)}
+          />
+          Use custom translations?
+        </label>
       </div>
 
       <h2>Feedback collection test</h2>
@@ -53,10 +77,15 @@ export function App() {
             bucket.requestFeedback({
               featureId: "featA",
               userId: "123",
-              title: "Hello, how do you like the modal?",
+              title: customTranslations
+                ? "Bonjour, que pensez-vous du modal ?"
+                : "Hello, how do you like the modal?",
               position: { type: "MODAL" },
               onAfterSubmit: async (data) => console.log("Submitted:", data),
               onClose: () => console.log("Closed dialog"),
+              translations: customTranslations
+                ? CUSTOM_TRANSLATIONS
+                : undefined,
             });
           }}
         >
@@ -67,10 +96,15 @@ export function App() {
             bucket.requestFeedback({
               featureId: "featB",
               userId: "123",
-              title: "Hello, how do you like the dialog?",
+              title: customTranslations
+                ? "Bonjour, que pensez-vous du dialog ?"
+                : "Hello, how do you like the dialog?",
               position: { type: "DIALOG", placement },
               onAfterSubmit: async (data) => console.log("Submitted:", data),
               onClose: () => console.log("Closed dialog"),
+              translations: customTranslations
+                ? CUSTOM_TRANSLATIONS
+                : undefined,
             });
           }}
         >
@@ -81,10 +115,15 @@ export function App() {
             bucket.requestFeedback({
               featureId: "featC",
               userId: "123",
-              title: "Hello, how do you like the popover?",
+              title: customTranslations
+                ? "Bonjour, que pensez-vous du popover ?"
+                : "Hello, how do you like the popover?",
               position: { type: "POPOVER", anchor: currentTarget },
               onAfterSubmit: async (data) => console.log("Submitted:", data),
               onClose: () => console.log("closed dialog"),
+              translations: customTranslations
+                ? CUSTOM_TRANSLATIONS
+                : undefined,
             });
           }}
         >

--- a/src/feedback/FeedbackDialog.tsx
+++ b/src/feedback/FeedbackDialog.tsx
@@ -13,7 +13,11 @@ import {
 import { feedbackContainerId } from "./constants";
 import { FeedbackForm } from "./FeedbackForm";
 import styles from "./index.css?inline";
-import { OpenFeedbackFormOptions, WithRequired } from "./types";
+import {
+  FeedbackTranslations,
+  OpenFeedbackFormOptions,
+  WithRequired,
+} from "./types";
 
 type Position = Partial<
   Record<"top" | "left" | "right" | "bottom", number | string>
@@ -24,10 +28,24 @@ export type FeedbackDialogProps = WithRequired<
   "onSubmit" | "position"
 >;
 
+const DEFAULT_TRANSLATIONS: FeedbackTranslations = {
+  DefaultQuestionLabel: "How satisfied are you with this feature?",
+  QuestionPlaceholder: "How can we improve this feature?",
+  CommentLabel: "Leave a comment (optional)",
+  ScoreVeryDissatisfiedLabel: "Very dissatisfied",
+  ScoreDissatisfiedLabel: "Dissatisfied",
+  ScoreNeutralLabel: "Neutral",
+  ScoreSatisfiedLabel: "Satisfied",
+  ScoreVerySatisfiedLabel: "Very satisfied",
+  SuccessMessage: "Thank you for sending your feedback!",
+  SendButton: "Send",
+};
+
 export const FeedbackDialog: FunctionComponent<FeedbackDialogProps> = ({
   key,
-  title = "How satisfied are you with this feature?",
+  title = DEFAULT_TRANSLATIONS.DefaultQuestionLabel,
   position,
+  translations = DEFAULT_TRANSLATIONS,
   onSubmit,
   onClose,
 }) => {
@@ -142,7 +160,12 @@ export const FeedbackDialog: FunctionComponent<FeedbackDialogProps> = ({
           <Close />
         </button>
 
-        <FeedbackForm key={key} question={title} onSubmit={onSubmit} />
+        <FeedbackForm
+          t={{ ...DEFAULT_TRANSLATIONS, ...translations }}
+          key={key}
+          question={title}
+          onSubmit={onSubmit}
+        />
 
         <footer class="plug">
           Powered by <Logo /> Bucket

--- a/src/feedback/FeedbackForm.tsx
+++ b/src/feedback/FeedbackForm.tsx
@@ -3,7 +3,7 @@ import { useState } from "preact/hooks";
 
 import { Button } from "./Button";
 import { StarRating } from "./StarRating";
-import { Feedback } from "./types";
+import { Feedback, FeedbackTranslations } from "./types";
 
 function getFeedbackDataFromForm(el: HTMLFormElement): Feedback {
   const formData = new FormData(el);
@@ -15,6 +15,7 @@ function getFeedbackDataFromForm(el: HTMLFormElement): Feedback {
 }
 
 type FeedbackFormProps = {
+  t: FeedbackTranslations;
   question: string;
   onSubmit: (data: Feedback) => Promise<void> | void;
 };
@@ -22,6 +23,7 @@ type FeedbackFormProps = {
 export const FeedbackForm: FunctionComponent<FeedbackFormProps> = ({
   question,
   onSubmit,
+  t,
 }) => {
   const [hasRating, setHasRating] = useState(false);
   const [status, setStatus] = useState<"idle" | "submitting" | "submitted">(
@@ -56,7 +58,7 @@ export const FeedbackForm: FunctionComponent<FeedbackFormProps> = ({
     return (
       <div class="submitted">
         <p class="icon">🙏</p>
-        <p class="text">Thank you for sending your feedback!</p>
+        <p class="text">{t.SuccessMessage}</p>
       </div>
     );
   }
@@ -71,18 +73,18 @@ export const FeedbackForm: FunctionComponent<FeedbackFormProps> = ({
         <div id="bucket-feedback-score-label" class="label">
           {question}
         </div>
-        <StarRating name="score" onChange={() => setHasRating(true)} />
+        <StarRating t={t} name="score" onChange={() => setHasRating(true)} />
       </div>
 
       <div class="form-control">
         <label for="bucket-feedback-comment-label" class="label">
-          Leave a comment <span class="dimmed">(optional)</span>
+          {t.CommentLabel}
         </label>
         <textarea
           id="bucket-feedback-comment-label"
           class="textarea"
           name="comment"
-          placeholder="How can we improve this feature?"
+          placeholder={t.QuestionPlaceholder}
           rows={5}
         />
       </div>
@@ -94,7 +96,7 @@ export const FeedbackForm: FunctionComponent<FeedbackFormProps> = ({
         disabled={!hasRating || status === "submitting"}
         loadingText="Submitting"
       >
-        Send
+        {t.SendButton}
       </Button>
     </form>
   );

--- a/src/feedback/StarRating.tsx
+++ b/src/feedback/StarRating.tsx
@@ -5,37 +5,38 @@ import { Neutral } from "./icons/Neutral";
 import { Satisfied } from "./icons/Satisfied";
 import { VeryDissatisfied } from "./icons/VeryDissatisfied";
 import { VerySatisfied } from "./icons/VerySatisfied";
+import { FeedbackTranslations } from "./types";
 
 const scores = [
   {
     color: "var(--bucket-feedback-dialog-very-dissatisfied-color, #dd6b20)",
     bg: "var(--bucket-feedback-dialog-very-dissatisfied-bg, #fbd38d)",
     icon: <VeryDissatisfied />,
-    label: "Very dissatisfied",
+    getLabel: (t: FeedbackTranslations) => t.ScoreVeryDissatisfiedLabel,
   },
   {
     color: "var(--bucket-feedback-dialog-dissatisfied-color, #ed8936)",
     bg: "var(--bucket-feedback-dialog-dissatisfied-bg, #feebc8)",
     icon: <Dissatisfied />,
-    label: "Dissatisfied",
+    getLabel: (t: FeedbackTranslations) => t.ScoreDissatisfiedLabel,
   },
   {
     color: "var(--bucket-feedback-dialog-neutral-color, #787c91)",
     bg: "var(--bucket-feedback-dialog-neutral-bg, #e9e9ed)",
     icon: <Neutral />,
-    label: "Neutral",
+    getLabel: (t: FeedbackTranslations) => t.ScoreNeutralLabel,
   },
   {
     color: "var(--bucket-feedback-dialog-satisfied-color, #48bb78)",
     bg: "var(--bucket-feedback-dialog-satisfied-bg, #c6f6d5)",
     icon: <Satisfied />,
-    label: "Satisfied",
+    getLabel: (t: FeedbackTranslations) => t.ScoreSatisfiedLabel,
   },
   {
     color: "var(--bucket-feedback-dialog-very-satisfied-color, #38a169)",
     bg: "var(--bucket-feedback-dialog-very-satisfied-bg, #9ae6b4)",
     icon: <VerySatisfied />,
-    label: "Very satisfied",
+    getLabel: (t: FeedbackTranslations) => t.ScoreVerySatisfiedLabel,
   },
 ];
 
@@ -43,9 +44,11 @@ export type StarRatingProps = {
   name: string;
   value?: number;
   onChange?: h.JSX.GenericEventHandler<HTMLInputElement>;
+  t: FeedbackTranslations;
 };
 
 export const StarRating: FunctionComponent<StarRatingProps> = ({
+  t,
   name,
   value,
   onChange,
@@ -64,7 +67,7 @@ export const StarRating: FunctionComponent<StarRatingProps> = ({
         )}
       </style>
       <div class="star-rating-icons">
-        {scores.map(({ color, icon, label }, index) => (
+        {scores.map(({ color, icon, getLabel }, index) => (
           <>
             <input
               id={`bucket-feedback-score-${index + 1}`}
@@ -78,7 +81,7 @@ export const StarRating: FunctionComponent<StarRatingProps> = ({
               for={`bucket-feedback-score-${index + 1}`}
               class="button"
               style={{ color }}
-              aria-label={label}
+              aria-label={getLabel(t)}
             >
               {icon}
             </label>
@@ -86,8 +89,8 @@ export const StarRating: FunctionComponent<StarRatingProps> = ({
         ))}
       </div>
       <div class="star-rating-labels">
-        <span>{scores[0].label}</span>
-        <span>{scores[scores.length - 1].label}</span>
+        <span>{t.ScoreVeryDissatisfiedLabel}</span>
+        <span>{t.ScoreVerySatisfiedLabel}</span>
       </div>
     </div>
   );

--- a/src/feedback/types.ts
+++ b/src/feedback/types.ts
@@ -20,6 +20,7 @@ export interface OpenFeedbackFormOptions {
   key: string;
   title?: string;
   position?: FeedbackPosition;
+  translations?: Partial<FeedbackTranslations>;
   onSubmit: (data: Feedback) => Promise<void> | void;
   onClose?: () => void;
 }
@@ -31,3 +32,16 @@ export interface RequestFeedbackOptions
   companyId?: string;
   onAfterSubmit?: (data: Feedback) => void;
 }
+
+export type FeedbackTranslations = {
+  DefaultQuestionLabel: string;
+  QuestionPlaceholder: string;
+  CommentLabel: string;
+  ScoreVeryDissatisfiedLabel: string;
+  ScoreDissatisfiedLabel: string;
+  ScoreNeutralLabel: string;
+  ScoreSatisfiedLabel: string;
+  ScoreVerySatisfiedLabel: string;
+  SuccessMessage: string;
+  SendButton: string;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -367,6 +367,7 @@ export default function main() {
         key: options.featureId,
         title: options.title,
         position: options.position,
+        translations: options.translations,
         onClose: options.onClose,
         onSubmit: async (data) => {
           // Default onSubmit handler


### PR DESCRIPTION
- Allows overriding every string in the widget
- _except_ for the "Powered by Bucket" text.
- I removed the `dimmed` of the "(optional)" text above the comment. Looks a bit less nice, but felt awkward having to provide two translation keys here

<img width="686" alt="image" src="https://github.com/bucketco/bucket-tracking-sdk/assets/34348/c40be848-5433-4f6e-be2f-375ca93e76b4">
