### PR TITLE
Fix popover closing when releasing mouse outside of dialog

### DIFF
--- a/src/feedback/FeedbackDialog.tsx
+++ b/src/feedback/FeedbackDialog.tsx
@@ -147,7 +147,7 @@ export const FeedbackDialog: FunctionComponent<FeedbackDialogProps> = ({
       });
     });
 
-    window.addEventListener("click", clickOutsideHandler);
+    window.addEventListener("mousedown", clickOutsideHandler);
     window.addEventListener("keydown", escapeHandler);
     observer.observe(document.body, {
       subtree: true,
@@ -155,7 +155,7 @@ export const FeedbackDialog: FunctionComponent<FeedbackDialogProps> = ({
     });
 
     return () => {
-      window.removeEventListener("click", clickOutsideHandler);
+      window.removeEventListener("mousedown", clickOutsideHandler);
       window.removeEventListener("keydown", escapeHandler);
       observer.disconnect();
     };


### PR DESCRIPTION
For example, when selecting text within the popover textarea and releasing the mouse outside of it.

https://github.com/bucketco/bucket-tracking-sdk/assets/34348/03c0cf7d-2271-4ae3-b6ee-f57dfc2341da

