### PR TITLE
Fix 'flash' of full radial progress after submitting feedback

### DIFF
--- a/src/feedback/FeedbackDialog.tsx
+++ b/src/feedback/FeedbackDialog.tsx
@@ -198,7 +198,7 @@ export const FeedbackDialog: FunctionComponent<FeedbackDialogProps> = ({
         style={anchor ? floatingStyles : unanchoredPosition}
       >
         <button onClick={close} class="close">
-          {!autoClose.stopped && (
+          {!autoClose.stopped && autoClose.elapsedFraction > 0 && (
             <RadialProgress
               diameter={28}
               progress={1.0 - autoClose.elapsedFraction}


### PR DESCRIPTION
Tiny issue I noticed with the close button when submitting popover + modal forms. See the issue here: https://linear.app/bucket/issue/BUC-1475/fix-flash-of-full-radial-progress-after-submitting-feedback