### PR TITLE
Add text-wrap balance to widget title

### DIFF
--- a/src/feedback/FeedbackForm.css
+++ b/src/feedback/FeedbackForm.css
@@ -45,6 +45,7 @@
   font-size: 15px;
   font-weight: 400;
   line-height: 115%;
+  text-wrap: balance;
   max-width: calc(100% - 20px);
   margin-bottom: 6px;
 }


### PR DESCRIPTION
<img width="351" alt="image" src="https://github.com/bucketco/bucket-tracking-sdk/assets/34348/520e51bd-c986-457e-a9e3-834a5733624e">
