### PR TITLE
Visual widget tweaks (width, line-height)

### DIFF
--- a/src/feedback/FeedbackDialog.css
+++ b/src/feedback/FeedbackDialog.css
@@ -36,7 +36,7 @@
 
 .dialog {
   position: fixed;
-  width: 280px;
+  width: 210px;
   padding: 16px 22px 10px;
   font-size: var(--bucket-feedback-dialog-font-size, 1rem);
   font-family: var(

--- a/src/feedback/FeedbackForm.css
+++ b/src/feedback/FeedbackForm.css
@@ -48,6 +48,7 @@
   text-wrap: balance;
   max-width: calc(100% - 20px);
   margin-bottom: 6px;
+  line-height: 1.3;
 }
 
 .dimmed {
@@ -69,7 +70,7 @@
     Open Sans,
     sans-serif
   );
-
+  line-height: 1.3;
   resize: none;
 
   color: var(--bucket-feedback-dialog-color, #1e1f24);

--- a/src/feedback/FeedbackForm.tsx
+++ b/src/feedback/FeedbackForm.tsx
@@ -200,7 +200,7 @@ export const FeedbackForm: FunctionComponent<FeedbackFormProps> = ({
                 class="textarea"
                 name="comment"
                 placeholder={t.QuestionPlaceholder}
-                rows={5}
+                rows={4}
               />
             </div>
 


### PR DESCRIPTION
Two minor tweaks:
- Make the widget a tad slimmer in width by default since there's a lot of blank whitespace on the right, which makes it feel very left-heavy. Cons: it makes for less space in the question before it wraps + the feedback textarea becomes a bit smaller. I think both are acceptable though as it still allows for decent length of the question before wrapping to 2+ lines.
- Increase line-height somewhat for the title and textarea to give it slightly more breathing room

https://github.com/bucketco/bucket-tracking-sdk/assets/222419/1078f2eb-73e2-4eae-aecf-df0b5ccc858d

