### PR TITLE
Cache Ably auth-cookie

### DIFF
--- a/example/empty.html
+++ b/example/empty.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bucket Test</title>
+  </head>
+  <body></body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import type {
   TrackedEvent,
   User,
 } from "./types";
+import { getAuthToken } from "./prompt-storage";
 
 async function request(url: string, body: any) {
   return fetch(url, {
@@ -324,26 +325,33 @@ export default function main() {
 
     userId = resolveUser(userId);
 
+    const existingAuth = getAuthToken(userId);
+    let channel = existingAuth?.channel;
+
     // while initializing, consider the channel active
     liveSatisfactionActive = true;
     try {
-      const res = await request(`${getUrl()}/feedback/prompting-init`, {
-        userId,
-      });
+      if (!channel) {
+        const res = await request(`${getUrl()}/feedback/prompting-init`, {
+          userId,
+        });
 
-      log(`feedback prompting status sent`, res);
-      const body: { success: boolean; channel?: string } = await res.json();
-      if (!body.success || !body.channel) {
-        log(`feedback prompting not enabled`);
-        return res;
+        log(`feedback prompting status sent`, res);
+        const body: { success: boolean; channel?: string } = await res.json();
+        if (!body.success || !body.channel) {
+          log(`feedback prompting not enabled`);
+          return res;
+        }
+
+        channel = body.channel;
       }
 
-      log(`feedback prompting enabled`);
+      log(`feedback prompting enabled`, channel);
 
       sseChannel = openAblySSEChannel(
         `${getUrl()}/feedback/prompting-auth`,
         userId,
-        body.channel,
+        channel,
         (message) => handleFeedbackPromptRequest(userId!, message),
         { debug, sseHost },
       );
@@ -351,11 +359,11 @@ export default function main() {
       feedbackPromptingUserId = userId;
 
       log(`feedback prompting connection established`);
-      return res;
     } finally {
       // check that SSE channel has actually been opened, otherwise reset the value
       liveSatisfactionActive = !!sseChannel;
     }
+    return channel;
   }
 
   function handleFeedbackPromptRequest(userId: User["userId"], message: any) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import type { FeedbackPosition, FeedbackTranslations } from "./feedback/types";
 import { SSE_REALTIME_HOST, TRACKING_HOST } from "./config";
 import { createDefaultFeedbackPromptHandler } from "./default-feedback-prompt-handler";
 import * as feedbackLib from "./feedback";
+import { getAuthToken } from "./prompt-storage";
 import {
   FeedbackPromptCompletionHandler,
   parsePromptMessage,
@@ -27,7 +28,6 @@ import type {
   TrackedEvent,
   User,
 } from "./types";
-import { getAuthToken } from "./prompt-storage";
 
 async function request(url: string, body: any) {
   return fetch(url, {

--- a/src/prompt-storage.ts
+++ b/src/prompt-storage.ts
@@ -5,7 +5,11 @@ export const markPromptMessageCompleted = (
   promptId: string,
   expiresAt: Date,
 ) => {
-  Cookies.set(`bucket-prompt-${userId}`, promptId, { expires: expiresAt });
+  Cookies.set(`bucket-prompt-${userId}`, promptId, {
+    expires: expiresAt,
+    sameSite: "strict",
+    secure: true,
+  });
 };
 
 export const checkPromptMessageCompleted = (
@@ -21,7 +25,11 @@ export const rememberAuthToken = (
   token: string,
   expiresAt: Date,
 ) => {
-  Cookies.set(`bucket-token-${userId}`, token, { expires: expiresAt });
+  Cookies.set(`bucket-token-${userId}`, token, {
+    expires: expiresAt,
+    sameSite: "strict",
+    secure: true,
+  });
 };
 
 export const getAuthToken = (userId: string) => {

--- a/src/prompt-storage.ts
+++ b/src/prompt-storage.ts
@@ -15,3 +15,15 @@ export const checkPromptMessageCompleted = (
   const id = Cookies.get(`bucket-prompt-${userId}`);
   return id === promptId;
 };
+
+export const rememberAuthToken = (
+  userId: string,
+  token: string,
+  expiresAt: Date,
+) => {
+  Cookies.set(`bucket-token-${userId}`, token, { expires: expiresAt });
+};
+
+export const getAuthToken = (userId: string) => {
+  return Cookies.get(`bucket-token-${userId}`);
+};

--- a/src/prompt-storage.ts
+++ b/src/prompt-storage.ts
@@ -41,7 +41,7 @@ export const getAuthToken = (userId: string) => {
 
   const [channel, token] = val.split(":");
   if (!channel?.length || !token?.length) {
-    throw new Error(`Invalid token: ${val}`);
+    return undefined;
   }
 
   return {

--- a/src/prompt-storage.ts
+++ b/src/prompt-storage.ts
@@ -22,10 +22,11 @@ export const checkPromptMessageCompleted = (
 
 export const rememberAuthToken = (
   userId: string,
+  channel: string,
   token: string,
   expiresAt: Date,
 ) => {
-  Cookies.set(`bucket-token-${userId}`, token, {
+  Cookies.set(`bucket-token-${userId}`, `${channel}:${token}`, {
     expires: expiresAt,
     sameSite: "strict",
     secure: true,
@@ -33,5 +34,18 @@ export const rememberAuthToken = (
 };
 
 export const getAuthToken = (userId: string) => {
-  return Cookies.get(`bucket-token-${userId}`);
+  const val = Cookies.get(`bucket-token-${userId}`);
+  if (!val) {
+    return undefined;
+  }
+
+  const [channel, token] = val.split(":");
+  if (!channel?.length || !token?.length) {
+    throw new Error(`Invalid token: ${val}`);
+  }
+
+  return {
+    channel,
+    token,
+  };
 };

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -77,10 +77,10 @@ export class AblySSEChannel {
   }
 
   private async refreshToken() {
-    const token = getAuthToken(this.userId);
-    if (token) {
-      this.log("using existing token", token);
-      return token;
+    const cached = getAuthToken(this.userId);
+    if (cached && cached.channel === this.channel) {
+      this.log("using existing token", cached.channel, cached.token);
+      return cached.token;
     }
 
     const tokenRequest = await this.refreshTokenRequest();
@@ -99,9 +99,14 @@ export class AblySSEChannel {
 
     if (res.ok) {
       const details: AblyTokenDetails = await res.json();
-      this.log("obtained new token", token);
+      this.log("obtained new token", details);
 
-      rememberAuthToken(this.userId, details.token, new Date(details.expires));
+      rememberAuthToken(
+        this.userId,
+        this.channel,
+        details.token,
+        new Date(details.expires),
+      );
       return details.token;
     }
 

--- a/test/e2e/acceptance.browser.spec.ts
+++ b/test/e2e/acceptance.browser.spec.ts
@@ -4,6 +4,9 @@ import { expect, test } from "@playwright/test";
 const KEY = randomUUID();
 
 test("Acceptance", async ({ page }) => {
+  const k = await page.goto("http://localhost:8000/example/empty.html");
+  console.log("YESSSSSSS", k?.ok() || "FECK");
+
   const successfulRequests: string[] = [];
 
   // Mock API calls with assertions

--- a/test/e2e/acceptance.browser.spec.ts
+++ b/test/e2e/acceptance.browser.spec.ts
@@ -4,8 +4,7 @@ import { expect, test } from "@playwright/test";
 const KEY = randomUUID();
 
 test("Acceptance", async ({ page }) => {
-  const k = await page.goto("http://localhost:8000/example/empty.html");
-  console.log("YESSSSSSS", k?.ok() || "FECK");
+  await page.goto("http://localhost:8000/example/empty.html");
 
   const successfulRequests: string[] = [];
 

--- a/test/e2e/feedback-widget.browser.spec.ts
+++ b/test/e2e/feedback-widget.browser.spec.ts
@@ -26,6 +26,8 @@ function pick<T>(options: T[]): T {
 }
 
 async function getOpenedWidgetContainer(page: Page, initOptions: Options = {}) {
+  await page.goto("http://localhost:8000/example/empty.html");
+
   // Mock API calls
   await page.route(`${TRACKING_HOST}/${KEY}/user`, async (route) => {
     await route.fulfill({ status: 200 });

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -67,7 +67,7 @@ describe("prompt-storage", () => {
   test("getAuthToken with error", async () => {
     const spy = vi.spyOn(Cookies, "get").mockReturnValue("token" as any);
 
-    expect(() => getAuthToken("user")).toThrowError();
+    expect(getAuthToken("user")).toBeUndefined();
 
     expect(spy).toHaveBeenCalledWith("bucket-token-user");
   });

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -56,7 +56,10 @@ describe("prompt-storage", () => {
       .spyOn(Cookies, "get")
       .mockReturnValue("channel:token" as any);
 
-    expect(getAuthToken("user")).toBe({ channel: "channel", token: "token" });
+    expect(getAuthToken("user")).toStrictEqual({
+      channel: "channel",
+      token: "token",
+    });
 
     expect(spy).toHaveBeenCalledWith("bucket-token-user");
   });

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, test, vi } from "vitest";
 
 import {
   checkPromptMessageCompleted,
+  getAuthToken,
   markPromptMessageCompleted,
+  rememberAuthToken,
 } from "../src/prompt-storage";
 
 vi.mock("js-cookie");
@@ -33,5 +35,31 @@ describe("prompt-storage", () => {
     expect(checkPromptMessageCompleted("user", "prompt")).toBe(false);
 
     expect(spy).toHaveBeenCalledWith("bucket-prompt-user");
+  });
+
+  test("rememberAuthToken", async () => {
+    const spy = vi.spyOn(Cookies, "set");
+
+    rememberAuthToken("user", "token", new Date("2021-01-01"));
+
+    expect(spy).toHaveBeenCalledWith("bucket-token-user", "token", {
+      expires: new Date("2021-01-01"),
+    });
+  });
+
+  test("getAuthToken with positive result", async () => {
+    const spy = vi.spyOn(Cookies, "get").mockReturnValue("other" as any);
+
+    expect(getAuthToken("user")).toBe("other");
+
+    expect(spy).toHaveBeenCalledWith("bucket-token-user");
+  });
+
+  test("getAuthToken with positive result", async () => {
+    const spy = vi.spyOn(Cookies, "get").mockReturnValue(undefined as any);
+
+    expect(getAuthToken("user")).toBeUndefined();
+
+    expect(spy).toHaveBeenCalledWith("bucket-token-user");
   });
 });

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -42,9 +42,9 @@ describe("prompt-storage", () => {
   test("rememberAuthToken", async () => {
     const spy = vi.spyOn(Cookies, "set");
 
-    rememberAuthToken("user", "token", new Date("2021-01-01"));
+    rememberAuthToken("user", "channel", "token", new Date("2021-01-01"));
 
-    expect(spy).toHaveBeenCalledWith("bucket-token-user", "token", {
+    expect(spy).toHaveBeenCalledWith("bucket-token-user", "channel:token", {
       expires: new Date("2021-01-01"),
       sameSite: "strict",
       secure: true,
@@ -52,14 +52,24 @@ describe("prompt-storage", () => {
   });
 
   test("getAuthToken with positive result", async () => {
-    const spy = vi.spyOn(Cookies, "get").mockReturnValue("other" as any);
+    const spy = vi
+      .spyOn(Cookies, "get")
+      .mockReturnValue("channel:token" as any);
 
-    expect(getAuthToken("user")).toBe("other");
+    expect(getAuthToken("user")).toBe({ channel: "channel", token: "token" });
 
     expect(spy).toHaveBeenCalledWith("bucket-token-user");
   });
 
-  test("getAuthToken with positive result", async () => {
+  test("getAuthToken with error", async () => {
+    const spy = vi.spyOn(Cookies, "get").mockReturnValue("token" as any);
+
+    expect(() => getAuthToken("user")).toThrowError();
+
+    expect(spy).toHaveBeenCalledWith("bucket-token-user");
+  });
+
+  test("getAuthToken with negative result", async () => {
     const spy = vi.spyOn(Cookies, "get").mockReturnValue(undefined as any);
 
     expect(getAuthToken("user")).toBeUndefined();

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -18,6 +18,8 @@ describe("prompt-storage", () => {
 
     expect(spy).toHaveBeenCalledWith("bucket-prompt-user", "prompt", {
       expires: new Date("2021-01-01"),
+      sameSite: "strict",
+      secure: true,
     });
   });
 
@@ -44,6 +46,8 @@ describe("prompt-storage", () => {
 
     expect(spy).toHaveBeenCalledWith("bucket-token-user", "token", {
       expires: new Date("2021-01-01"),
+      sameSite: "strict",
+      secure: true,
     });
   });
 

--- a/test/sse.test.ts
+++ b/test/sse.test.ts
@@ -141,9 +141,10 @@ describe("connection handling", () => {
 
     await sse.connect();
 
-    expect(getAuthToken).toHaveBeenCalledWith(userId, channel);
+    expect(getAuthToken).toHaveBeenCalledWith(userId);
     expect(rememberAuthToken).toHaveBeenCalledWith(
       userId,
+      channel,
       "token",
       new Date("2023-01-01T00:00:00.000Z"),
     );

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -332,7 +332,7 @@ describe("feedback prompting", () => {
     );
 
     expect(n.isDone()).toBe(false);
-    n.done;
+    n.done();
   });
 
   test("does not initiate feedback prompting if server does not agree", async () => {

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -303,11 +303,18 @@ describe("feedback prompting", () => {
     expect(closeAblySSEChannel).toBeCalledWith("fake_client");
   });
 
-  test("does not call tracking endpoint if token cached", async () => {
+  test("does not call tracking endpoints if token cached", async () => {
     vi.mocked(getAuthToken).mockReturnValue({
       channel: "super-channel",
       token: "something",
     });
+
+    const n = nock(`${TRACKING_HOST}/${KEY}`)
+      .post(/.*\/feedback\/prompting-init/, {
+        userId: "foo",
+      })
+      .reply(200, { success: true, channel: "test-channel" });
+
     const bucketInstance = bucket();
     bucketInstance.init(KEY, {
       persistUser: false,
@@ -323,6 +330,9 @@ describe("feedback prompting", () => {
       expect.anything(),
       expect.anything(),
     );
+
+    expect(n.isDone()).toBe(false);
+    n.done;
   });
 
   test("does not initiate feedback prompting if server does not agree", async () => {

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -242,7 +242,7 @@ describe("usage", () => {
   });
 });
 
-describe("fetdback prompting", () => {
+describe("feedback prompting", () => {
   beforeAll(() => {
     vi.mocked(openAblySSEChannel).mockReturnValue("fake_client" as any);
     vi.mocked(closeAblySSEChannel).mockResolvedValue(undefined);

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -332,7 +332,6 @@ describe("feedback prompting", () => {
     );
 
     expect(n.isDone()).toBe(false);
-    n.done();
   });
 
   test("does not initiate feedback prompting if server does not agree", async () => {


### PR DESCRIPTION
* Cache the cookie locally (for its validity time),
* Also, added cookie settings to avoid Firefox complaints: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value