### PR TITLE
fix: auth cookie serialization/deserialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@preact/preset-vite": "^2.5.0",
     "@types/js-cookie": "^3.0.3",
     "@types/node": "^20.4.4",
+    "@types/jsdom": "^21.1.6",
     "@types/webpack": "^5.28.2",
     "@types/webpack-node-externals": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/tracking-sdk",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "license": "MIT",
   "private": false,
   "repository": {

--- a/src/prompt-storage.ts
+++ b/src/prompt-storage.ts
@@ -26,7 +26,7 @@ export const rememberAuthToken = (
   token: string,
   expiresAt: Date,
 ) => {
-  Cookies.set(`bucket-token-${userId}`, JSON.stringify([channel,token]), {
+  Cookies.set(`bucket-token-${userId}`, JSON.stringify([channel, token]), {
     expires: expiresAt,
     sameSite: "strict",
     secure: true,

--- a/src/prompt-storage.ts
+++ b/src/prompt-storage.ts
@@ -26,7 +26,7 @@ export const rememberAuthToken = (
   token: string,
   expiresAt: Date,
 ) => {
-  Cookies.set(`bucket-token-${userId}`, JSON.stringify([channel, token]), {
+  Cookies.set(`bucket-token-${userId}`, JSON.stringify({ channel, token }), {
     expires: expiresAt,
     sameSite: "strict",
     secure: true,
@@ -40,7 +40,10 @@ export const getAuthToken = (userId: string) => {
   }
 
   try {
-    const [channel, token] = JSON.parse(val);
+    const { channel, token } = JSON.parse(val) as {
+      channel: string;
+      token: string;
+    };
     if (!channel?.length || !token?.length) {
       return undefined;
     }

--- a/src/prompt-storage.ts
+++ b/src/prompt-storage.ts
@@ -26,7 +26,7 @@ export const rememberAuthToken = (
   token: string,
   expiresAt: Date,
 ) => {
-  Cookies.set(`bucket-token-${userId}`, `${channel}:${token}`, {
+  Cookies.set(`bucket-token-${userId}`, JSON.stringify([channel,token]), {
     expires: expiresAt,
     sameSite: "strict",
     secure: true,
@@ -39,13 +39,16 @@ export const getAuthToken = (userId: string) => {
     return undefined;
   }
 
-  const [channel, token] = val.split(":");
-  if (!channel?.length || !token?.length) {
+  try {
+    const [channel, token] = JSON.parse(val);
+    if (!channel?.length || !token?.length) {
+      return undefined;
+    }
+    return {
+      channel,
+      token,
+    };
+  } catch (e) {
     return undefined;
   }
-
-  return {
-    channel,
-    token,
-  };
 };

--- a/src/prompt-storage.ts
+++ b/src/prompt-storage.ts
@@ -52,3 +52,7 @@ export const getAuthToken = (userId: string) => {
     return undefined;
   }
 };
+
+export const forgetAuthToken = (userId: string) => {
+  Cookies.remove(`bucket-token-${userId}`);
+};

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -1,7 +1,11 @@
 import fetch from "cross-fetch";
 
 import { SSE_REALTIME_HOST } from "./config";
-import { getAuthToken, rememberAuthToken } from "./prompt-storage";
+import {
+  forgetAuthToken,
+  getAuthToken,
+  rememberAuthToken,
+} from "./prompt-storage";
 
 interface AblyTokenDetails {
   token: string;
@@ -12,8 +16,8 @@ interface AblyTokenRequest {
   keyName: string;
 }
 
-const ABLY_TOKEN_ERROR_MIN = 40140;
-const ABLY_TOKEN_ERROR_MAX = 40149;
+const ABLY_TOKEN_ERROR_MIN = 40000;
+const ABLY_TOKEN_ERROR_MAX = 49999;
 
 export class AblySSEChannel {
   private isOpen: boolean = false;
@@ -130,6 +134,7 @@ export class AblySSEChannel {
         errorCode <= ABLY_TOKEN_ERROR_MAX
       ) {
         this.log("event source token expired, refresh required");
+        forgetAuthToken(this.userId);
       }
     } else {
       const connectionState = (e as any)?.target?.readyState;

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 
 import {
   checkPromptMessageCompleted,
+  forgetAuthToken,
   getAuthToken,
   markPromptMessageCompleted,
   rememberAuthToken,
@@ -58,6 +59,14 @@ describe("prompt-storage", () => {
         secure: true,
       },
     );
+  });
+
+  test("forgetAuthToken", async () => {
+    const spy = vi.spyOn(Cookies, "remove");
+
+    forgetAuthToken("user");
+
+    expect(spy).toHaveBeenCalledWith("bucket-token-user");
   });
 
   test("getAuthToken with positive result", async () => {

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -44,7 +44,7 @@ describe("prompt-storage", () => {
 
     rememberAuthToken("user", "channel", "token", new Date("2021-01-01"));
 
-    expect(spy).toHaveBeenCalledWith("bucket-token-user", "channel:token", {
+    expect(spy).toHaveBeenCalledWith("bucket-token-user", "[\"channel\",\"token\"]", {
       expires: new Date("2021-01-01"),
       sameSite: "strict",
       secure: true,
@@ -54,7 +54,7 @@ describe("prompt-storage", () => {
   test("getAuthToken with positive result", async () => {
     const spy = vi
       .spyOn(Cookies, "get")
-      .mockReturnValue("channel:token" as any);
+      .mockReturnValue("[\"channel\",\"token\"]" as any);
 
     expect(getAuthToken("user")).toStrictEqual({
       channel: "channel",

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
 
 import {
   checkPromptMessageCompleted,
@@ -33,6 +41,10 @@ describe("prompt-storage", () => {
   afterEach(() => {
     document.cookie = undefined!;
     vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
   });
 
   describe("markPromptMessageCompleted", () => {

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -44,17 +44,21 @@ describe("prompt-storage", () => {
 
     rememberAuthToken("user", "channel", "token", new Date("2021-01-01"));
 
-    expect(spy).toHaveBeenCalledWith("bucket-token-user", "[\"channel\",\"token\"]", {
-      expires: new Date("2021-01-01"),
-      sameSite: "strict",
-      secure: true,
-    });
+    expect(spy).toHaveBeenCalledWith(
+      "bucket-token-user",
+      '["channel","token"]',
+      {
+        expires: new Date("2021-01-01"),
+        sameSite: "strict",
+        secure: true,
+      },
+    );
   });
 
   test("getAuthToken with positive result", async () => {
     const spy = vi
       .spyOn(Cookies, "get")
-      .mockReturnValue("[\"channel\",\"token\"]" as any);
+      .mockReturnValue('["channel","token"]' as any);
 
     expect(getAuthToken("user")).toStrictEqual({
       channel: "channel",

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -42,11 +42,11 @@ describe("prompt-storage", () => {
   test("rememberAuthToken", async () => {
     const spy = vi.spyOn(Cookies, "set");
 
-    rememberAuthToken("user", "channel", "token", new Date("2021-01-01"));
+    rememberAuthToken("user", "channel:suffix", "token", new Date("2021-01-01"));
 
     expect(spy).toHaveBeenCalledWith(
       "bucket-token-user",
-      '["channel","token"]',
+      '["channel:suffix","token"]',
       {
         expires: new Date("2021-01-01"),
         sameSite: "strict",
@@ -58,10 +58,10 @@ describe("prompt-storage", () => {
   test("getAuthToken with positive result", async () => {
     const spy = vi
       .spyOn(Cookies, "get")
-      .mockReturnValue('["channel","token"]' as any);
+      .mockReturnValue('["channel:suffix","token"]' as any);
 
     expect(getAuthToken("user")).toStrictEqual({
-      channel: "channel",
+      channel: "channel:suffix",
       token: "token",
     });
 

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -42,7 +42,12 @@ describe("prompt-storage", () => {
   test("rememberAuthToken", async () => {
     const spy = vi.spyOn(Cookies, "set");
 
-    rememberAuthToken("user", "channel:suffix", "token", new Date("2021-01-01"));
+    rememberAuthToken(
+      "user",
+      "channel:suffix",
+      "token",
+      new Date("2021-01-01"),
+    );
 
     expect(spy).toHaveBeenCalledWith(
       "bucket-token-user",

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -46,13 +46,13 @@ describe("prompt-storage", () => {
     rememberAuthToken(
       "user",
       "channel:suffix",
-      "token",
+      "secret$%",
       new Date("2021-01-01"),
     );
 
     expect(spy).toHaveBeenCalledWith(
       "bucket-token-user",
-      '["channel:suffix","token"]',
+      '{"channel":"channel:suffix","token":"secret$%"}',
       {
         expires: new Date("2021-01-01"),
         sameSite: "strict",
@@ -72,11 +72,13 @@ describe("prompt-storage", () => {
   test("getAuthToken with positive result", async () => {
     const spy = vi
       .spyOn(Cookies, "get")
-      .mockReturnValue('["channel:suffix","token"]' as any);
+      .mockReturnValue(
+        '{"channel":"channel:suffix","token":"secret%$"}' as any,
+      );
 
     expect(getAuthToken("user")).toStrictEqual({
       channel: "channel:suffix",
-      token: "token",
+      token: "secret%$",
     });
 
     expect(spy).toHaveBeenCalledWith("bucket-token-user");
@@ -84,6 +86,16 @@ describe("prompt-storage", () => {
 
   test("getAuthToken with error", async () => {
     const spy = vi.spyOn(Cookies, "get").mockReturnValue("token" as any);
+
+    expect(getAuthToken("user")).toBeUndefined();
+
+    expect(spy).toHaveBeenCalledWith("bucket-token-user");
+  });
+
+  test("getAuthToken with empty field", async () => {
+    const spy = vi
+      .spyOn(Cookies, "get")
+      .mockReturnValue('{"channel":"","token":"secret%$"}' as any);
 
     expect(getAuthToken("user")).toBeUndefined();
 

--- a/test/prompt-storage.test.ts
+++ b/test/prompt-storage.test.ts
@@ -1,5 +1,4 @@
-import Cookies from "js-cookie";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 
 import {
   checkPromptMessageCompleted,
@@ -9,104 +8,217 @@ import {
   rememberAuthToken,
 } from "../src/prompt-storage";
 
-vi.mock("js-cookie");
-
 describe("prompt-storage", () => {
-  test("markPromptMessageCompleted", async () => {
-    const spy = vi.spyOn(Cookies, "set");
+  beforeAll(() => {
+    const cookies: Record<string, string> = {};
 
-    markPromptMessageCompleted("user", "prompt", new Date("2021-01-01"));
-
-    expect(spy).toHaveBeenCalledWith("bucket-prompt-user", "prompt", {
-      expires: new Date("2021-01-01"),
-      sameSite: "strict",
-      secure: true,
-    });
-  });
-
-  test("checkPromptMessageCompleted with positive result", async () => {
-    const spy = vi.spyOn(Cookies, "get").mockReturnValue("prompt" as any);
-
-    expect(checkPromptMessageCompleted("user", "prompt")).toBe(true);
-
-    expect(spy).toHaveBeenCalledWith("bucket-prompt-user");
-  });
-
-  test("checkPromptMessageCompleted with negative result", async () => {
-    const spy = vi.spyOn(Cookies, "get").mockReturnValue("other" as any);
-
-    expect(checkPromptMessageCompleted("user", "prompt")).toBe(false);
-
-    expect(spy).toHaveBeenCalledWith("bucket-prompt-user");
-  });
-
-  test("rememberAuthToken", async () => {
-    const spy = vi.spyOn(Cookies, "set");
-
-    rememberAuthToken(
-      "user",
-      "channel:suffix",
-      "secret$%",
-      new Date("2021-01-01"),
-    );
-
-    expect(spy).toHaveBeenCalledWith(
-      "bucket-token-user",
-      '{"channel":"channel:suffix","token":"secret$%"}',
-      {
-        expires: new Date("2021-01-01"),
-        sameSite: "strict",
-        secure: true,
+    Object.defineProperty(document, "cookie", {
+      set: (val: string) => {
+        if (!val) {
+          Object.keys(cookies).forEach((k) => delete cookies[k]);
+          return;
+        }
+        const i = val.indexOf("=");
+        cookies[val.slice(0, i)] = val.slice(i + 1);
       },
-    );
+      get: () =>
+        Object.entries(cookies)
+          .map(([k, v]) => `${k}=${v}`)
+          .join("; "),
+    });
+
+    vi.setSystemTime(new Date("2024-01-11T09:55:37.000Z"));
   });
 
-  test("forgetAuthToken", async () => {
-    const spy = vi.spyOn(Cookies, "remove");
-
-    forgetAuthToken("user");
-
-    expect(spy).toHaveBeenCalledWith("bucket-token-user");
+  afterEach(() => {
+    document.cookie = undefined!;
+    vi.clearAllMocks();
   });
 
-  test("getAuthToken with positive result", async () => {
-    const spy = vi
-      .spyOn(Cookies, "get")
-      .mockReturnValue(
-        '{"channel":"channel:suffix","token":"secret%$"}' as any,
+  describe("markPromptMessageCompleted", () => {
+    test("adds new cookie", async () => {
+      markPromptMessageCompleted(
+        "user",
+        "prompt2",
+        new Date("2024-01-04T14:01:20.000Z"),
       );
 
-    expect(getAuthToken("user")).toStrictEqual({
-      channel: "channel:suffix",
-      token: "secret%$",
+      expect(document.cookie).toBe(
+        "bucket-prompt-user=prompt2; path=/; expires=Thu, 04 Jan 2024 14:01:20 GMT; sameSite=strict; secure",
+      );
     });
 
-    expect(spy).toHaveBeenCalledWith("bucket-token-user");
+    test("rewrites existing cookie", async () => {
+      document.cookie =
+        "bucket-prompt-user=prompt1; path=/; expires=Thu, 04 Jan 2021 14:01:20 GMT; sameSite=strict; secure";
+
+      markPromptMessageCompleted(
+        "user",
+        "prompt2",
+        new Date("2024-01-04T14:01:20.000Z"),
+      );
+
+      expect(document.cookie).toBe(
+        "bucket-prompt-user=prompt2; path=/; expires=Thu, 04 Jan 2024 14:01:20 GMT; sameSite=strict; secure",
+      );
+    });
   });
 
-  test("getAuthToken with error", async () => {
-    const spy = vi.spyOn(Cookies, "get").mockReturnValue("token" as any);
+  describe("checkPromptMessageCompleted", () => {
+    test("cookie with same use and prompt results in true", async () => {
+      document.cookie =
+        "bucket-prompt-user=prompt; path=/; expires=Thu, 04 Jan 2024 14:01:20 GMT; sameSite=strict; secure";
 
-    expect(getAuthToken("user")).toBeUndefined();
+      expect(checkPromptMessageCompleted("user", "prompt")).toBe(true);
 
-    expect(spy).toHaveBeenCalledWith("bucket-token-user");
+      expect(document.cookie).toBe(
+        "bucket-prompt-user=prompt; path=/; expires=Thu, 04 Jan 2024 14:01:20 GMT; sameSite=strict; secure",
+      );
+    });
+
+    test("cookie with different prompt results in false", async () => {
+      document.cookie =
+        "bucket-prompt-user=prompt1; path=/; expires=Thu, 04 Jan 2024 14:01:20 GMT; sameSite=strict; secure";
+
+      expect(checkPromptMessageCompleted("user", "prompt2")).toBe(false);
+    });
+
+    test("cookie with different user results in false", async () => {
+      document.cookie =
+        "bucket-prompt-user1=prompt1; path=/; expires=Thu, 04 Jan 2024 14:01:20 GMT; sameSite=strict; secure";
+
+      expect(checkPromptMessageCompleted("user2", "prompt1")).toBe(false);
+    });
+
+    test("no cookie results in false", async () => {
+      expect(checkPromptMessageCompleted("user", "prompt2")).toBe(false);
+    });
   });
 
-  test("getAuthToken with empty field", async () => {
-    const spy = vi
-      .spyOn(Cookies, "get")
-      .mockReturnValue('{"channel":"","token":"secret%$"}' as any);
+  describe("rememberAuthToken", () => {
+    test("adds new cookie if none was there", async () => {
+      expect(document.cookie).toBe("");
 
-    expect(getAuthToken("user")).toBeUndefined();
+      rememberAuthToken(
+        'user1"%%',
+        "channel:suffix",
+        "secret$%",
+        new Date("2024-01-02T15:02:20.000Z"),
+      );
 
-    expect(spy).toHaveBeenCalledWith("bucket-token-user");
+      expect(document.cookie).toBe(
+        "bucket-token-user1%22%25%25={%22channel%22:%22channel:suffix%22%2C%22token%22:%22secret$%25%22}; path=/; expires=Tue, 02 Jan 2024 15:02:20 GMT; sameSite=strict; secure",
+      );
+    });
+
+    test("replaces existing cookie for same user", async () => {
+      document.cookie =
+        "bucket-token-user1%22%25%25={%22channel%22:%22channel:suffix%22%2C%22token%22:%22secret$%25%22}; path=/; expires=Tue, 02 Jan 2024 15:02:20 GMT; sameSite=strict; secure";
+
+      rememberAuthToken(
+        'user1"%%',
+        "channel2:suffix2",
+        "secret2$%",
+        new Date("2023-01-02T15:02:20.000Z"),
+      );
+
+      expect(document.cookie).toBe(
+        "bucket-token-user1%22%25%25={%22channel%22:%22channel2:suffix2%22%2C%22token%22:%22secret2$%25%22}; path=/; expires=Mon, 02 Jan 2023 15:02:20 GMT; sameSite=strict; secure",
+      );
+    });
   });
 
-  test("getAuthToken with negative result", async () => {
-    const spy = vi.spyOn(Cookies, "get").mockReturnValue(undefined as any);
+  describe("forgetAuthToken", () => {
+    test("clears the user's cookie if even if there was nothing before", async () => {
+      forgetAuthToken("user");
 
-    expect(getAuthToken("user")).toBeUndefined();
+      expect(document.cookie).toBe(
+        "bucket-token-user=; path=/; expires=Wed, 10 Jan 2024 09:55:37 GMT",
+      );
+    });
 
-    expect(spy).toHaveBeenCalledWith("bucket-token-user");
+    test("clears the user's cookie", async () => {
+      document.cookie =
+        "bucket-token-user1={%22channel%22:%22channel:suffix%22%2C%22token%22:%22secret$%25%22}; path=/; expires=Tue, 02 Jan 2024 15:02:20 GMT; sameSite=strict; secure";
+
+      forgetAuthToken("user1");
+
+      expect(document.cookie).toBe(
+        "bucket-token-user1=; path=/; expires=Wed, 10 Jan 2024 09:55:37 GMT",
+      );
+    });
+
+    test("does nothing if there is a cookie for a different user", async () => {
+      document.cookie =
+        "bucket-token-user1={%22channel%22:%22channel:suffix%22%2C%22token%22:%22secret$%25%22}; path=/; expires=Tue, 02 Jan 2028 15:02:20 GMT; sameSite=strict; secure";
+
+      forgetAuthToken("user2");
+
+      expect(document.cookie).toBe(
+        "bucket-token-user1={%22channel%22:%22channel:suffix%22%2C%22token%22:%22secret$%25%22}; path=/; expires=Tue, 02 Jan 2028 15:02:20 GMT; sameSite=strict; secure; bucket-token-user2=; path=/; expires=Wed, 10 Jan 2024 09:55:37 GMT",
+      );
+    });
+  });
+
+  describe("getAuthToken", () => {
+    test("returns the auth token if it's available for the user", async () => {
+      document.cookie =
+        "bucket-token-user1%22%25%25={%22channel%22:%22channel:suffix%22%2C%22token%22:%22secret$%25%22}; path=/; expires=Tue, 02 Jan 2024 15:02:20 GMT; sameSite=strict; secure";
+
+      expect(getAuthToken('user1"%%')).toStrictEqual({
+        channel: "channel:suffix",
+        token: "secret$%",
+      });
+    });
+
+    test("return undefined if no cookie for user", async () => {
+      document.cookie =
+        "bucket-token-user1={%22channel%22:%22channel:suffix%22%2C%22token%22:%22secret$%25%22}; path=/; expires=Tue, 02 Jan 2024 15:02:20 GMT; sameSite=strict; secure";
+
+      expect(getAuthToken("user2")).toBeUndefined();
+    });
+
+    test("returns undefined if no cookie", async () => {
+      expect(getAuthToken("user")).toBeUndefined();
+    });
+
+    test("return undefined if corrupted cookie", async () => {
+      document.cookie =
+        "bucket-token-user={channel%22:%22channel:suffix%22%2C%22token%22:%22secret$%25%22}; path=/; expires=Tue, 02 Jan 2024 15:02:20 GMT; sameSite=strict; secure";
+
+      expect(getAuthToken("user")).toBeUndefined();
+    });
+
+    test("return undefined if a field is missing", async () => {
+      document.cookie =
+        "bucket-token-user={%2C%22token%22:%22secret$%25%22}; path=/; expires=Tue, 02 Jan 2024 15:02:20 GMT; sameSite=strict; secure";
+
+      expect(getAuthToken("user")).toBeUndefined();
+    });
+  });
+
+  test("manages all cookies for the user", () => {
+    rememberAuthToken(
+      "user1",
+      "channel:suffix",
+      "secret$%",
+      new Date("2024-01-02T15:02:20.000Z"),
+    );
+
+    markPromptMessageCompleted(
+      "user1",
+      "alex-prompt",
+      new Date("2024-01-02T15:03:20.000Z"),
+    );
+
+    expect(document.cookie).toBe(
+      "bucket-token-user1={%22channel%22:%22channel:suffix%22%2C%22token%22:%22secret$%25%22}; path=/; expires=Tue, 02 Jan 2024 15:02:20 GMT; sameSite=strict; secure; bucket-prompt-user1=alex-prompt; path=/; expires=Tue, 02 Jan 2024 15:03:20 GMT; sameSite=strict; secure",
+    );
+
+    forgetAuthToken("user1");
+
+    expect(document.cookie).toBe(
+      "bucket-token-user1=; path=/; expires=Wed, 10 Jan 2024 09:55:37 GMT; bucket-prompt-user1=alex-prompt; path=/; expires=Tue, 02 Jan 2024 15:03:20 GMT; sameSite=strict; secure",
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1025,6 +1025,15 @@
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.3.tgz#d6bfbbdd0c187354ca555213d1962f6d0691ff4e"
   integrity sha512-Xe7IImK09HP1sv2M/aI+48a20VX+TdRJucfq4vfRVy6nWN8PYPOEnlMRSgxJAgYQIXJVL8dZ4/ilAM7dWNaOww==
 
+"@types/jsdom@^21.1.6":
+  version "21.1.6"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-21.1.6.tgz#bcbc7b245787ea863f3da1ef19aa1dcfb9271a1b"
+  integrity sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==
+  dependencies:
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    parse5 "^7.0.0"
+
 "@types/json-schema@*", "@types/json-schema@^7.0.8":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
@@ -1054,6 +1063,11 @@
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
   integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
+
+"@types/tough-cookie@*":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
+  integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
 "@types/webpack-node-externals@^3.0.0":
   version "3.0.0"
@@ -3733,7 +3747,7 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
-parse5@^7.1.2:
+parse5@^7.0.0, parse5@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz#0736bebbfd77793823240a23b7fc5e010b7f8e32"
   integrity sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==


### PR DESCRIPTION
This PR fixes an issue with cached token serialization and adds preventive fix in case a token is manually modified or possibly invalid due to server-side credential changes.