### PR TITLE
Include SDK version in the auth call and improve config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/tracking-sdk",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "license": "MIT",
   "private": false,
   "repository": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,2 +1,8 @@
+import { version } from "../package.json";
+
 export const TRACKING_HOST = "https://tracking.bucket.co";
 export const SSE_REALTIME_HOST = "https://livemessaging.bucket.co";
+
+export const SDK_VERSION_HEADER_NAME = "Bucket-Sdk-Version";
+
+export const SDK_VERSION = version;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,13 @@
 import fetch from "cross-fetch";
 import { isForNode } from "is-bundling-for-browser-or-node";
 
-import { version } from "../package.json";
-
 import type { FeedbackPosition, FeedbackTranslations } from "./feedback/types";
-import { SSE_REALTIME_HOST, TRACKING_HOST } from "./config";
+import {
+  SDK_VERSION,
+  SDK_VERSION_HEADER_NAME,
+  SSE_REALTIME_HOST,
+  TRACKING_HOST,
+} from "./config";
 import { createDefaultFeedbackPromptHandler } from "./default-feedback-prompt-handler";
 import * as feedbackLib from "./feedback";
 import { getAuthToken } from "./prompt-storage";
@@ -34,7 +37,7 @@ async function request(url: string, body: any) {
     method: "post",
     headers: {
       "Content-Type": "application/json",
-      "Bucket-Sdk-Version": version,
+      [SDK_VERSION_HEADER_NAME]: SDK_VERSION,
     },
     body: JSON.stringify(body),
   });
@@ -576,6 +579,7 @@ export default function main() {
     // lifecycle
     init,
     reset,
+    version: SDK_VERSION,
     // requests
     user,
     company,

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -1,6 +1,10 @@
 import fetch from "cross-fetch";
 
-import { SSE_REALTIME_HOST } from "./config";
+import {
+  SDK_VERSION,
+  SDK_VERSION_HEADER_NAME,
+  SSE_REALTIME_HOST,
+} from "./config";
 import {
   forgetAuthToken,
   getAuthToken,
@@ -62,6 +66,7 @@ export class AblySSEChannel {
         method: "get",
         headers: {
           "Content-Type": "application/json",
+          [SDK_VERSION_HEADER_NAME]: SDK_VERSION,
         },
       },
     );

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -12,7 +12,11 @@ import {
 } from "vitest";
 
 import { version } from "../package.json";
-import { TRACKING_HOST } from "../src/config";
+import {
+  SDK_VERSION,
+  SDK_VERSION_HEADER_NAME,
+  TRACKING_HOST,
+} from "../src/config";
 import bucket from "../src/main";
 import {
   checkPromptMessageCompleted,
@@ -208,7 +212,7 @@ describe("usage", () => {
   test("will send sdk version as header", async () => {
     nock(`${TRACKING_HOST}/${KEY}`, {
       reqheaders: {
-        "Bucket-Sdk-Version": version,
+        [SDK_VERSION_HEADER_NAME]: version,
       },
     })
       .post(/.*\/user/, {
@@ -219,6 +223,12 @@ describe("usage", () => {
     const bucketInstance = bucket();
     bucketInstance.init(KEY);
     await bucketInstance.user("foo");
+  });
+
+  test("will send sdk version as header", async () => {
+    const bucketInstance = bucket();
+
+    expect(bucketInstance.version).toBe(SDK_VERSION);
   });
 
   test("can reset user", async () => {


### PR DESCRIPTION
We were not including the SDK version into the `/auth` call for some reason. This PR remedies that. Also re-arranged come code to make it shareable.