### PR TITLE
Fix test data mock that fails when run in a non-UTC timezone

### DIFF
--- a/test/sse.test.ts
+++ b/test/sse.test.ts
@@ -21,7 +21,7 @@ const tokenRequest = {
 };
 const tokenDetails = {
   token: "token",
-  expires: new Date(2023, 0, 1).getTime(),
+  expires: new Date("2023-01-01T00:00:00.000Z").getTime(),
 };
 
 const userId = "foo";


### PR DESCRIPTION
I had this test fail with the classic one hour timezone difference

```
 FAIL  test/sse.test.ts > connection handling > does not reuse cached token with wrong channel
AssertionError: expected "spy" to be called with arguments: [ 'foo', 'channel', 'token', …(1) ]

Received:

  1st spy call:

  Array [
    "foo",
    "channel",
    "token",
-   2023-01-01T00:00:00.000Z,
+   2022-12-31T23:00:00.000Z,
```