### PR TITLE
Always allow userId override with explicit argument

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -98,13 +98,15 @@ export default function main() {
   }
 
   function resolveUser(userId?: User["userId"]): string | never {
-    if (persistUser) {
-      return getSessionUser();
-    } else if (!userId) {
-      err("No userId provided and persistUser is disabled");
+    if (userId) {
+      return userId;
     }
 
-    return userId!;
+    if (persistUser) {
+      return getSessionUser();
+    } else {
+      err("No userId provided and persistUser is disabled");
+    }
   }
 
   /**
@@ -515,11 +517,7 @@ export default function main() {
       err("No featureId provided");
     }
 
-    if (persistUser) {
-      options.userId = getSessionUser();
-    } else if (!options.userId) {
-      err("No userId provided and persistUser is disabled");
-    }
+    const userId = resolveUser(options.userId);
 
     // Wait a tick before opening the feedback form,
     // to prevent the same click from closing it.
@@ -535,7 +533,7 @@ export default function main() {
         onScoreSubmit: async (data) => {
           const res = await feedback({
             featureId: options.featureId,
-            userId: options.userId,
+            userId,
             companyId: options.companyId,
             source: "widget",
             ...data,
@@ -548,7 +546,7 @@ export default function main() {
           // Default onSubmit handler
           await feedback({
             featureId: options.featureId,
-            userId: options.userId,
+            userId,
             companyId: options.companyId,
             source: "widget",
             ...data,

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -337,26 +337,6 @@ describe("usage", () => {
         .resolves;
     });
   });
-
-  test("can reset user", async () => {
-    nock(`${TRACKING_HOST}/${KEY}`)
-      .post(/.*\/user/, {
-        userId: "foo",
-        attributes: {
-          name: "john doe",
-        },
-      })
-      .reply(200);
-
-    const bucketInstance = bucket();
-    bucketInstance.init(KEY, { persistUser: true });
-    await bucketInstance.user("foo", { name: "john doe" });
-
-    bucketInstance.reset();
-    await expect(() => bucketInstance.track("foo")).rejects.toThrowError(
-      "User is not set, please call user() first",
-    );
-  });
 });
 
 describe("feedback prompting", () => {


### PR DESCRIPTION
This changes behavior to always prefer a passed-in userId over any persisted user id.

We've seen situations where race conditions can lead to en error being thrown by our SDK when following segments recommended approach to logging out:

```
analytics.track('Signed Out');
analytics.reset();
```

The bucket SDK can be reset before the event get tracked, which currently throws because only the persisted userId is taken into account, despite segment actually providing a userId explicitly in the `bucket.event()`-call

There is a possible discussion to be had on the behavior where both a persisted userId exists and an explicit userId is passed along. In this PR I treat the userId argument as authoritative, but we might want the behavior to be preferring the persisted userId if one exists