### PR TITLE
chore: Simplify types

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -172,7 +172,7 @@ export default function main() {
    */
   async function user(
     userId: string,
-    attributes?: Record<string,any>,
+    attributes?: Record<string, any>,
     context?: Context,
   ) {
     checkKey();
@@ -206,7 +206,7 @@ export default function main() {
    */
   async function company(
     companyId: string,
-    attributes?: Record<string,any> | null,
+    attributes?: Record<string, any> | null,
     userId?: string,
     context?: Context,
   ) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,7 +97,7 @@ export default function main() {
     throw new Error(message);
   }
 
-  function resolveUser(userId?: User["userId"]): string | never {
+  function resolveUser(userId?: string): string | never {
     if (persistUser) {
       return getSessionUser();
     } else if (!userId) {
@@ -171,8 +171,8 @@ export default function main() {
    * @param context
    */
   async function user(
-    userId: User["userId"],
-    attributes?: User["attributes"],
+    userId: string,
+    attributes?: Record<string,any>,
     context?: Context,
   ) {
     checkKey();
@@ -205,9 +205,9 @@ export default function main() {
    * @param context
    */
   async function company(
-    companyId: Company["companyId"],
-    attributes?: Company["attributes"] | null,
-    userId?: Company["userId"],
+    companyId: string,
+    attributes?: Record<string,any> | null,
+    userId?: string,
     context?: Context,
   ) {
     checkKey();
@@ -235,10 +235,10 @@ export default function main() {
    * @param context
    */
   async function track(
-    eventName: TrackedEvent["event"],
-    attributes?: TrackedEvent["attributes"] | null,
-    userId?: Company["userId"],
-    companyId?: Company["companyId"],
+    eventName: string,
+    attributes?: Record<string, any> | null,
+    userId?: string,
+    companyId?: string,
     context?: Context,
   ) {
     checkKey();
@@ -280,7 +280,7 @@ export default function main() {
     if (!score && !comment) err("Either 'score' or 'comment' must be provided");
     userId = resolveUser(userId);
 
-    const payload: Feedback & { userId: User["userId"] } = {
+    const payload: Feedback & { userId: string } = {
       feedbackId,
       userId,
       featureId,
@@ -310,7 +310,7 @@ export default function main() {
    *
    * @param userId The ID you use to identify the user
    */
-  async function initLiveSatisfaction(userId?: User["userId"]) {
+  async function initLiveSatisfaction(userId?: string) {
     checkKey();
 
     if (isForNode) {
@@ -369,7 +369,7 @@ export default function main() {
     return channel;
   }
 
-  function handleFeedbackPromptRequest(userId: User["userId"], message: any) {
+  function handleFeedbackPromptRequest(userId: string, message: any) {
     const parsed = parsePromptMessage(message);
     if (!parsed) {
       err(`invalid feedback prompt message received`, message);
@@ -395,7 +395,7 @@ export default function main() {
   }
 
   async function triggerFeedbackPrompt(
-    userId: User["userId"],
+    userId: string,
     message: FeedbackPrompt,
     completionHandler: FeedbackPromptCompletionHandler,
   ) {
@@ -480,7 +480,7 @@ export default function main() {
     featureId: string;
     promptId: string;
     promptedQuestion: string;
-    userId: User["userId"];
+    userId: string;
   }) {
     checkKey();
     if (!args.promptId) err("No promptId provided");

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -2,7 +2,7 @@ import {
   checkPromptMessageCompleted,
   markPromptMessageCompleted,
 } from "./prompt-storage";
-import { FeedbackPrompt, User } from "./types";
+import { FeedbackPrompt } from "./types";
 
 export const parsePromptMessage = (
   message: any,
@@ -31,13 +31,13 @@ export const parsePromptMessage = (
 
 export type FeedbackPromptCompletionHandler = () => void;
 export type FeedbackPromptDisplayHandler = (
-  userId: User["userId"],
+  userId: string,
   prompt: FeedbackPrompt,
   completionHandler: FeedbackPromptCompletionHandler,
 ) => void;
 
 export const processPromptMessage = (
-  userId: User["userId"],
+  userId: string,
   prompt: FeedbackPrompt,
   displayHandler: FeedbackPromptDisplayHandler,
 ) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export type User = {
 };
 
 export type Company = {
-  userId: User["userId"];
+  userId: string;
   companyId: string;
   attributes?: {
     name?: string;
@@ -59,11 +59,9 @@ export type Company = {
 
 export type TrackedEvent = {
   event: string;
-  userId: User["userId"];
-  companyId?: Company["companyId"];
-  attributes?: {
-    [key: string]: any;
-  };
+  userId: string;
+  companyId?: string;
+  attributes?: Record<string, any>;
   context?: Context;
 };
 
@@ -111,12 +109,12 @@ export type Feedback = {
   /**
    * User ID from your own application.
    */
-  userId?: User["userId"];
+  userId?: string;
 
   /**
    * Company ID from your own application.
    */
-  companyId?: Company["companyId"];
+  companyId?: string;
 
   /**
    * The question that was presented to the user.
@@ -164,14 +162,14 @@ export type FeedbackPrompt = {
   showAfter: Date;
   showBefore: Date;
   promptId: string;
-  featureId: Feedback["featureId"];
+  featureId: string;
 };
 
 export type FeedbackPromptReply = {
   question: string;
-  companyId?: Company["companyId"];
-  score?: FeedbackSubmission["score"];
-  comment?: FeedbackSubmission["comment"];
+  companyId?: string;
+  score?: number;
+  comment?: string;
 };
 
 export type FeedbackPromptReplyHandler = <T extends FeedbackPromptReply | null>(


### PR DESCRIPTION
We've been using type lookup (?) which diminished readability. These types are part of the API now and they will never change so might as well use those types directly.

No types are actually changing here, just the way we write them