### PR TITLE
fix: send SDK version along with fetch requests

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,6 @@ import { version } from "../package.json";
 export const TRACKING_HOST = "https://tracking.bucket.co";
 export const SSE_REALTIME_HOST = "https://livemessaging.bucket.co";
 
-export const SDK_VERSION_HEADER_NAME = "Bucket-Sdk-Version";
+export const SDK_VERSION_HEADER_NAME = "bucket-sdk-version";
 
 export const SDK_VERSION = version;

--- a/src/flags-fetch.ts
+++ b/src/flags-fetch.ts
@@ -1,8 +1,8 @@
 import fetch from "cross-fetch";
 
+import { SDK_VERSION, SDK_VERSION_HEADER_NAME } from "./config";
 import { Flags } from "./flags";
 import { FlagCache, isObject, validateFlags } from "./flags-cache";
-import { SDK_VERSION, SDK_VERSION_HEADER_NAME } from "./config";
 
 // Deep merge two objects.
 export function mergeDeep(

--- a/src/flags-fetch.ts
+++ b/src/flags-fetch.ts
@@ -81,10 +81,10 @@ export async function fetchFlags(url: string, timeoutMs: number) {
       const id = setTimeout(() => controller.abort(), timeoutMs);
 
       // add SDK version to the query params
-      const separator = url.includes("?") ? "&" : "?";
-      const newUrl = `${url}${separator}${SDK_VERSION_HEADER_NAME}=${SDK_VERSION}`;
+      const urlObj = new URL(url);
+      urlObj.searchParams.append(SDK_VERSION_HEADER_NAME, SDK_VERSION);
 
-      const res = await fetch(newUrl, {
+      const res = await fetch(urlObj, {
         signal: controller.signal,
       });
       clearTimeout(id);

--- a/src/flags-fetch.ts
+++ b/src/flags-fetch.ts
@@ -2,6 +2,7 @@ import fetch from "cross-fetch";
 
 import { Flags } from "./flags";
 import { FlagCache, isObject, validateFlags } from "./flags-cache";
+import { SDK_VERSION, SDK_VERSION_HEADER_NAME } from "./config";
 
 // Deep merge two objects.
 export function mergeDeep(
@@ -78,7 +79,12 @@ export async function fetchFlags(url: string, timeoutMs: number) {
     try {
       const controller = new AbortController();
       const id = setTimeout(() => controller.abort(), timeoutMs);
-      const res = await fetch(url, {
+
+      // add SDK version to the query params
+      const separator = url.includes("?") ? "&" : "?";
+      const newUrl = `${url}${separator}${SDK_VERSION_HEADER_NAME}=${SDK_VERSION}`;
+
+      const res = await fetch(newUrl, {
         signal: controller.signal,
       });
       clearTimeout(id);


### PR DESCRIPTION
We're using a GET request to avoid CORS preflight requests for feature flags. This requires us to send the SDK version information along in a query string instead of the custom header we use for POST requests.

Updated the header/query param name to be lower-case. For headers it doesn't matter because headers are case-insensitive, but for the query param it's simpler to just have things be lower-case.