### PR TITLE
Fix behaviour around failed FF responses

### DIFF
--- a/packages/tracking-sdk/src/flags-fetch.ts
+++ b/packages/tracking-sdk/src/flags-fetch.ts
@@ -100,7 +100,7 @@ export async function fetchFlags(url: string, timeoutMs: number) {
       if (success) {
         cache.set(url, success, flags);
       } else {
-        const current = cache.get(url)
+        const current = cache.get(url);
         if (current) {
           // if there is a previous version, extend it's expireAt time
           cache.set(url, current.success, current.flags);

--- a/packages/tracking-sdk/test/flags.test.ts
+++ b/packages/tracking-sdk/test/flags.test.ts
@@ -141,7 +141,7 @@ describe("getFlags unit tests", () => {
         flags: {
           featureB: { value: true, key: "featureB" },
         },
-      }
+      };
 
       expect(vi.mocked(fetch).mock.calls.length).toBe(0);
 
@@ -191,7 +191,7 @@ describe("getFlags unit tests", () => {
     test("when stale cache is failed response", async () => {
       const response = {
         success: false,
-      }
+      };
 
       expect(vi.mocked(fetch).mock.calls.length).toBe(0);
 
@@ -234,7 +234,7 @@ describe("getFlags unit tests", () => {
 
       expect(b).toEqual({
         featureB: { value: true, key: "featureB" },
-      })
+      });
 
       // new fetch was fired
       expect(vi.mocked(fetch).mock.calls.length).toBe(2);

--- a/packages/tracking-sdk/test/flags.test.ts
+++ b/packages/tracking-sdk/test/flags.test.ts
@@ -94,7 +94,7 @@ describe("getFlags unit tests", () => {
     expect(vi.mocked(fetch).mock.calls.length).toBe(1);
   });
 
-  test("caches negative response", async () => {
+  test("refetches on negative response", async () => {
     vi.mocked(fetch).mockRejectedValue(new Error("Failed to fetch flags"));
 
     expect(vi.mocked(fetch).mock.calls.length).toBe(0);
@@ -110,12 +110,39 @@ describe("getFlags unit tests", () => {
       context: { user: { id: "123" } },
       timeoutMs: 1000,
     });
+
     expect(b).toBeUndefined();
-    expect(vi.mocked(fetch).mock.calls.length).toBe(1);
+    expect(vi.mocked(fetch).mock.calls.length).toBe(2);
   });
 
-  describe("serves stale cache while reevaluating", async () => {
-    async function runTest(response) {
+  test("maintains previously successful flags on negative response", async () => {
+    await getFlags({
+      apiBaseUrl: "https://localhost",
+      context: { user: { id: "123" } },
+      timeoutMs: 1000,
+    });
+
+    vi.mocked(fetch).mockRejectedValue(new Error("Failed to fetch flags"));
+    vi.advanceTimersByTime(60000);
+
+    const staleFlags = await getFlags({
+      apiBaseUrl: "https://localhost",
+      context: { user: { id: "123" } },
+      timeoutMs: 1000,
+    });
+
+    expect(staleFlags).toEqual(flagsResponse.flags);
+  });
+
+  describe("stale cache while reevaluating", async () => {
+    test("when stale cache is success response", async () => {
+      const response = {
+        success: true,
+        flags: {
+          featureB: { value: true, key: "featureB" },
+        },
+      }
+
       expect(vi.mocked(fetch).mock.calls.length).toBe(0);
 
       vi.mocked(fetch).mockResolvedValue({
@@ -159,21 +186,58 @@ describe("getFlags unit tests", () => {
 
       // new fetch was fired
       expect(vi.mocked(fetch).mock.calls.length).toBe(2);
-    }
-
-    test("with positive result", async () => {
-      await runTest({
-        success: true,
-        flags: {
-          featureB: { value: true, key: "featureB" },
-        },
-      });
     });
 
-    test("with negative result", async () => {
-      await runTest({
+    test("when stale cache is failed response", async () => {
+      const response = {
         success: false,
+      }
+
+      expect(vi.mocked(fetch).mock.calls.length).toBe(0);
+
+      vi.mocked(fetch).mockResolvedValue({
+        status: 200,
+        ok: true,
+        json: function () {
+          return Promise.resolve(response);
+        },
+      } as Response);
+
+      await getFlags({
+        apiBaseUrl: "https://localhost",
+        context: { user: { id: "123" } },
+        timeoutMs: 1000,
       });
+
+      // change the response so we can validate that we'll serve the stale cache
+      vi.mocked(fetch).mockResolvedValue({
+        status: 200,
+        ok: true,
+        json: function () {
+          return Promise.resolve({
+            success: true,
+            flags: {
+              featureB: { value: true, key: "featureB" },
+            },
+          });
+        },
+      } as Response);
+
+      vi.advanceTimersByTime(FLAGS_STALE_MS + 1);
+
+      const b = await getFlags({
+        apiBaseUrl: "https://localhost",
+        context: { user: { id: "123" } },
+        timeoutMs: 1000,
+        staleWhileRevalidate: true,
+      });
+
+      expect(b).toEqual({
+        featureB: { value: true, key: "featureB" },
+      })
+
+      // new fetch was fired
+      expect(vi.mocked(fetch).mock.calls.length).toBe(2);
     });
   });
 

--- a/packages/tracking-sdk/test/flags.test.ts
+++ b/packages/tracking-sdk/test/flags.test.ts
@@ -94,27 +94,6 @@ describe("getFlags unit tests", () => {
     expect(vi.mocked(fetch).mock.calls.length).toBe(1);
   });
 
-  test("refetches on negative response", async () => {
-    vi.mocked(fetch).mockRejectedValue(new Error("Failed to fetch flags"));
-
-    expect(vi.mocked(fetch).mock.calls.length).toBe(0);
-
-    await getFlags({
-      apiBaseUrl: "https://localhost",
-      context: { user: { id: "123" } },
-      timeoutMs: 1000,
-    });
-
-    const b = await getFlags({
-      apiBaseUrl: "https://localhost",
-      context: { user: { id: "123" } },
-      timeoutMs: 1000,
-    });
-
-    expect(b).toBeUndefined();
-    expect(vi.mocked(fetch).mock.calls.length).toBe(2);
-  });
-
   test("maintains previously successful flags on negative response", async () => {
     await getFlags({
       apiBaseUrl: "https://localhost",


### PR DESCRIPTION
The behaviour on a failed response is now to:
- try and extend the expiration of the last cached response if possible
- cache the failure if not
- but always refetch on load if the cached response is a failure