### PR TITLE
fix: do not log error if flag is simply disabled

### DIFF
--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -131,10 +131,6 @@ export function useFeatureFlag(key: string) {
   const flags = useContext<BucketContext>(Context).flags;
   const flag = flags.flags[key];
 
-  if (!flags.isLoading && flag === undefined) {
-    console.error(`[Bucket SDK] The feature flag "${key}" was not found`);
-  }
-
   const value = flag?.value ?? null;
 
   return { isLoading: flags.isLoading, value: value };

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -177,38 +177,6 @@ describe("useFeatureFlag", () => {
     expect(result.current).toEqual({ isLoading: false, value: value });
     expect(console.error).not.toHaveBeenCalled();
   });
-
-  test("fails when given a missing feature flag", async () => {
-    console.error = vi.fn();
-
-    const flags = {
-      abc: { value: true, key: "abc" },
-      def: { value: false, key: "abc" },
-    };
-
-    const sdk = createSpySDK();
-    sdk.getFeatureFlags = vi.fn(async () => flags);
-
-    const publishableKey = Math.random().toString();
-    const flagOptions = { context: {} };
-
-    const { result } = renderHook(() => useFeatureFlag("does-not-exist"), {
-      wrapper: ({ children }) => (
-        <Bucket
-          sdk={sdk}
-          publishableKey={publishableKey}
-          flags={flagOptions}
-          children={children}
-        />
-      ),
-    });
-
-    await waitFor(() => result.current.isLoading === false);
-    expect(result.current).toEqual({ isLoading: false, value: null });
-    expect(console.error).toHaveBeenCalledWith(
-      '[Bucket SDK] The feature flag "does-not-exist" was not found',
-    );
-  });
 });
 
 function createSpySDK(): BucketInstance {

--- a/packages/tracking-sdk/src/flags-fetch.ts
+++ b/packages/tracking-sdk/src/flags-fetch.ts
@@ -95,7 +95,7 @@ export async function fetchFlags(url: string, timeoutMs: number) {
       flags = typeRes.flags;
       success = true;
     } catch (e) {
-      console.error("fetching flags: ", e);
+      console.error("[Bucket] error fetching flags: ", e);
     } finally {
       if (success) {
         cache.set(url, success, flags);


### PR DESCRIPTION
only enabled flags are returned from the API.