### PR TITLE
Unable to publish due to missing publish config

### DIFF
--- a/packages/flag-evaluation/package.json
+++ b/packages/flag-evaluation/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "https://github.com/bucketco/bucket-tracking-sdk.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "test": "jest",


### PR DESCRIPTION
See publish failure here: https://github.com/bucketco/bucket-tracking-sdk/actions/runs/9548138256/job/26314637159#step:7:19